### PR TITLE
Automate dependency version updates and add macOS arm64 artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,33 @@ env:
   PNGOUT_VERSION: 1.0.0 # http://advsys.net/ken/utils.htm#pngout - manual version
   ZOPFLI_VERSION: "1.0.3" # https://github.com/google/zopfli/tags
   OXIPNG_VERSION: "10.1.0" # https://github.com/shssoichiro/oxipng/releases
-  FFMPEG_VERSION: "8.0" # https://github.com/BtbN/FFmpeg-Builds/releases
-  RCLONE_VERSION: "v1.73.1" # https://github.com/rclone/rclone/releases
-  IMAGEMAGICK_VERSION: "7.1.2-13" # https://github.com/ImageMagick/ImageMagick/releases/latest
+  FFMPEG_VERSION: "8.1" # https://github.com/BtbN/FFmpeg-Builds/releases
+  RCLONE_VERSION: "v1.73.3" # https://github.com/rclone/rclone/releases
+  IMAGEMAGICK_VERSION: "7.1.2-18" # https://github.com/ImageMagick/ImageMagick/releases/latest
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
-    needs: [versions_json, zopflipng-linux, zopflipng-windows, oxipng-linux, oxipng-windows, ffmpeg-linux, ffmpeg-linux-arm64, ffmpeg-windows, ffmpeg-windows-arm64, pngout-linux, pngout-windows, rclone-windows, rclone-linux, magick-windows]
+    needs: [
+      versions_json,
+      zopflipng-linux,
+      zopflipng-windows,
+      zopflipng-osx-arm64,
+      oxipng-linux,
+      oxipng-windows,
+      oxipng-osx-arm64,
+      ffmpeg-linux,
+      ffmpeg-linux-arm64,
+      ffmpeg-windows,
+      ffmpeg-windows-arm64,
+      ffmpeg-osx-arm64,
+      pngout-linux,
+      pngout-windows,
+      rclone-windows,
+      rclone-linux,
+      rclone-osx-arm64,
+      magick-windows
+    ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
@@ -63,13 +82,18 @@ jobs:
       with:
         repository: google/zopfli
         ref: zopfli-${{ env.ZOPFLI_VERSION }}
-    - run: make zopflipng
+    - run: make zopfli && make zopflipng
+    - run: |
+        mv zopfli zopfli-linux-x64
+        mv zopflipng zopflipng-linux-x64
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-zopflipng-linux
         if-no-files-found: error
         retention-days: 1
-        path: 'zopflipng'
+        path: |
+          zopfli-linux-x64
+          zopflipng-linux-x64
 
   zopflipng-windows:
     runs-on: windows-latest
@@ -99,64 +123,102 @@ jobs:
 
         Write-Host "Linking zopflipng.exe"
         & link -nologo /LTCG /OUT:zopflipng.exe *.obj user32.lib advapi32.lib kernel32.lib
+        Move-Item zopfli.exe zopfli-win-x64.exe
+        Move-Item zopflipng.exe zopflipng-win-x64.exe
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-zopflipng-windows
         if-no-files-found: error
         retention-days: 1
         path: |
-          zopfli.exe
-          zopflipng.exe
+          zopfli-win-x64.exe
+          zopflipng-win-x64.exe
+
+  zopflipng-osx-arm64:
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        repository: google/zopfli
+        ref: zopfli-${{ env.ZOPFLI_VERSION }}
+    - run: make zopfli && make zopflipng
+    - run: |
+        Move-Item zopfli zopfli-osx-arm64
+        Move-Item zopflipng zopflipng-osx-arm64
+    - uses: actions/upload-artifact@v7
+      with:
+        name: binaries-zopflipng-osx-arm64
+        if-no-files-found: error
+        retention-days: 1
+        path: |
+          zopfli-osx-arm64
+          zopflipng-osx-arm64
 
   oxipng-windows:
     runs-on: ubuntu-latest
     steps:
     - run: Invoke-WebRequest -Uri 'https://github.com/shssoichiro/oxipng/releases/download/v${{ env.OXIPNG_VERSION }}/oxipng-${{ env.OXIPNG_VERSION }}-x86_64-pc-windows-msvc.zip' -OutFile oxipng.zip
     - run: Expand-Archive oxipng.zip -DestinationPath .
-    - run: Get-ChildItem -Path ".\" -Recurse -Filter "oxipng.exe" | Copy-Item -Destination ".\"
+    - run: |
+        Get-ChildItem -Path ".\" -Recurse -Filter "oxipng.exe" | Copy-Item -Destination ".\"
+        Move-Item oxipng.exe oxipng-win-x64.exe
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-oxipng-windows
         if-no-files-found: error
         retention-days: 1
-        path: 'oxipng.exe'
+        path: 'oxipng-win-x64.exe'
 
   oxipng-linux:
     runs-on: ubuntu-latest
     steps:
     - run: Invoke-WebRequest -Uri 'https://github.com/shssoichiro/oxipng/releases/download/v${{ env.OXIPNG_VERSION }}/oxipng-${{ env.OXIPNG_VERSION }}-x86_64-unknown-linux-musl.tar.gz' -OutFile oxipng.tar.gz
     - run: tar -xvf oxipng.tar.gz
-    - run: mv oxipng-*-x86_64-unknown-linux-musl/oxipng oxipng
+    - run: mv oxipng-*-x86_64-unknown-linux-musl/oxipng oxipng-linux-x64
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-oxipng-linux
         if-no-files-found: error
         retention-days: 1
-        path: 'oxipng'
+        path: 'oxipng-linux-x64'
+
+  oxipng-osx-arm64:
+    runs-on: ubuntu-latest
+    steps:
+    - run: Invoke-WebRequest -Uri 'https://github.com/shssoichiro/oxipng/releases/download/v${{ env.OXIPNG_VERSION }}/oxipng-${{ env.OXIPNG_VERSION }}-aarch64-apple-darwin.tar.gz' -OutFile oxipng.tar.gz
+    - run: tar -xvf oxipng.tar.gz
+    - run: mv oxipng-*-aarch64-apple-darwin/oxipng oxipng-osx-arm64
+    - uses: actions/upload-artifact@v7
+      with:
+        name: binaries-oxipng-osx-arm64
+        if-no-files-found: error
+        retention-days: 1
+        path: 'oxipng-osx-arm64'
 
   pngout-windows:
     runs-on: ubuntu-latest
     steps:
     - run: Invoke-WebRequest -Uri 'http://advsys.net/ken/util/pngout.exe' -OutFile pngout.exe
+    - run: Move-Item pngout.exe pngout-win-x64.exe
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-pngout-windows
         if-no-files-found: error
         retention-days: 1
-        path: pngout.exe
+        path: pngout-win-x64.exe
 
   pngout-linux:
     runs-on: ubuntu-latest
     steps:
     - run: Invoke-WebRequest -Uri 'http://www.jonof.id.au/files/kenutils/pngout-20200115-linux.tar.gz' -OutFile pngout.tar.gz
     - run: tar -xvf pngout.tar.gz
-    - run: mv pngout-*/amd64/pngout pngout
+    - run: mv pngout-*/amd64/pngout pngout-linux-x64
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-pngout-linux
         if-no-files-found: error
         retention-days: 1
-        path: pngout
+        path: pngout-linux-x64
 
   ffmpeg-windows:
     runs-on: ubuntu-latest
@@ -167,19 +229,21 @@ jobs:
          "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
        }
 
-       $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest -Headers $headers
-       $WindowsAsset = $release.assets | Where-Object { $_.name -cmatch '^ffmpeg-.*-win64-gpl-${{ env.FFMPEG_VERSION }}.zip$' }
-       Invoke-WebRequest -Uri $WindowsAsset.browser_download_url -OutFile ffmpeg.zip
-       Expand-Archive ffmpeg.zip -DestinationPath . -Verbose
-       Get-ChildItem -Recurse -Include ffmpeg.exe, ffprobe.exe | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
+        $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest -Headers $headers
+        $WindowsAsset = $release.assets | Where-Object { $_.name -cmatch '^ffmpeg-.*-win64-gpl-${{ env.FFMPEG_VERSION }}.zip$' }
+        Invoke-WebRequest -Uri $WindowsAsset.browser_download_url -OutFile ffmpeg.zip
+        Expand-Archive ffmpeg.zip -DestinationPath . -Verbose
+        Get-ChildItem -Recurse -Include ffmpeg.exe, ffprobe.exe | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
+        Move-Item ffmpeg.exe ffmpeg-win-x64.exe
+        Move-Item ffprobe.exe ffprobe-win-x64.exe
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-windows
         if-no-files-found: error
         retention-days: 1
         path: |
-           ffmpeg.exe
-           ffprobe.exe
+           ffmpeg-win-x64.exe
+           ffprobe-win-x64.exe
 
   ffmpeg-windows-arm64:
     runs-on: ubuntu-latest
@@ -190,21 +254,21 @@ jobs:
          "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
        }
 
-       $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest -Headers $headers
-       $WindowsAsset = $release.assets | Where-Object { $_.name -cmatch '^ffmpeg-.*-winarm64-gpl-${{ env.FFMPEG_VERSION }}.zip$' }
-       Invoke-WebRequest -Uri $WindowsAsset.browser_download_url -OutFile ffmpeg.zip
-       Expand-Archive ffmpeg.zip -DestinationPath . -Verbose
-       Get-ChildItem -Recurse -Include ffmpeg.exe, ffprobe.exe | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
-       Move-Item ffmpeg.exe ffmpeg-arm64.exe
-       Move-Item ffprobe.exe ffprobe-arm64.exe
+        $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest -Headers $headers
+        $WindowsAsset = $release.assets | Where-Object { $_.name -cmatch '^ffmpeg-.*-winarm64-gpl-${{ env.FFMPEG_VERSION }}.zip$' }
+        Invoke-WebRequest -Uri $WindowsAsset.browser_download_url -OutFile ffmpeg.zip
+        Expand-Archive ffmpeg.zip -DestinationPath . -Verbose
+        Get-ChildItem -Recurse -Include ffmpeg.exe, ffprobe.exe | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
+        Move-Item ffmpeg.exe ffmpeg-win-arm64.exe
+        Move-Item ffprobe.exe ffprobe-win-arm64.exe
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-windows-arm64
         if-no-files-found: error
         retention-days: 1
         path: |
-           ffmpeg-arm64.exe
-           ffprobe-arm64.exe
+           ffmpeg-win-arm64.exe
+           ffprobe-win-arm64.exe
 
   ffmpeg-linux:
     runs-on: ubuntu-latest
@@ -215,19 +279,21 @@ jobs:
          "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
        }
 
-       $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest -Headers $headers
-       $LinuxAsset = $release.assets | Where-Object { $_.name -cmatch '^ffmpeg-.*-linux64-gpl-${{ env.FFMPEG_VERSION }}.tar.xz$' }
-       Invoke-WebRequest -Uri $LinuxAsset.browser_download_url -OutFile ffmpeg.tar.xz
-       tar -xvf ffmpeg.tar.xz
-       Get-ChildItem -Recurse -Include ffmpeg, ffprobe | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
+        $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest -Headers $headers
+        $LinuxAsset = $release.assets | Where-Object { $_.name -cmatch '^ffmpeg-.*-linux64-gpl-${{ env.FFMPEG_VERSION }}.tar.xz$' }
+        Invoke-WebRequest -Uri $LinuxAsset.browser_download_url -OutFile ffmpeg.tar.xz
+        tar -xvf ffmpeg.tar.xz
+        Get-ChildItem -Recurse -Include ffmpeg, ffprobe | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
+        Move-Item ffmpeg ffmpeg-linux-x64
+        Move-Item ffprobe ffprobe-linux-x64
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-linux
         if-no-files-found: error
         retention-days: 1
         path: |
-           ffmpeg
-           ffprobe
+           ffmpeg-linux-x64
+           ffprobe-linux-x64
 
   ffmpeg-linux-arm64:
     runs-on: ubuntu-latest
@@ -238,20 +304,43 @@ jobs:
          "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
        }
 
-       $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest -Headers $headers
-       $LinuxAsset = $release.assets | Where-Object { $_.name -cmatch '^ffmpeg-.*-linuxarm64-gpl-${{ env.FFMPEG_VERSION }}.tar.xz$' }
-       Invoke-WebRequest -Uri $LinuxAsset.browser_download_url -OutFile ffmpeg.tar.xz
-       tar -xvf ffmpeg.tar.xz
-       Get-ChildItem -Recurse -Filter ffmpeg | Foreach-Object { Move-Item -LiteralPath $_ -Destination ffmpeg-arm64 }
-       Get-ChildItem -Recurse -Filter ffprobe | Foreach-Object { Move-Item -LiteralPath $_ -Destination ffprobe-arm64 }
+        $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest -Headers $headers
+        $LinuxAsset = $release.assets | Where-Object { $_.name -cmatch '^ffmpeg-.*-linuxarm64-gpl-${{ env.FFMPEG_VERSION }}.tar.xz$' }
+        Invoke-WebRequest -Uri $LinuxAsset.browser_download_url -OutFile ffmpeg.tar.xz
+        tar -xvf ffmpeg.tar.xz
+        Get-ChildItem -Recurse -Filter ffmpeg | Foreach-Object { Move-Item -LiteralPath $_ -Destination ffmpeg-linux-arm64 }
+        Get-ChildItem -Recurse -Filter ffprobe | Foreach-Object { Move-Item -LiteralPath $_ -Destination ffprobe-linux-arm64 }
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-linux-arm64
         if-no-files-found: error
         retention-days: 1
         path: |
-           ffmpeg-arm64
-           ffprobe-arm64
+           ffmpeg-linux-arm64
+           ffprobe-linux-arm64
+
+  ffmpeg-osx-arm64:
+    runs-on: macos-14
+    steps:
+    - run: |
+       if (-not (Get-Command ffmpeg -ErrorAction SilentlyContinue)) {
+         brew install ffmpeg
+       }
+
+       if (-not (Get-Command ffprobe -ErrorAction SilentlyContinue)) {
+         brew install ffmpeg
+       }
+
+       Copy-Item (Get-Command ffmpeg).Source ffmpeg-osx-arm64
+       Copy-Item (Get-Command ffprobe).Source ffprobe-osx-arm64
+    - uses: actions/upload-artifact@v7
+      with:
+        name: binaries-ffmpeg-osx-arm64
+        if-no-files-found: error
+        retention-days: 1
+        path: |
+           ffmpeg-osx-arm64
+           ffprobe-osx-arm64
 
   rclone-windows:
     runs-on: ubuntu-latest
@@ -262,17 +351,18 @@ jobs:
          "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
        }
 
-       $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/rclone/rclone/releases/tags/${{ env.RCLONE_VERSION }} -Headers $headers
-       $WindowsAsset = $release.assets | Where-Object { $_.name -cmatch '^rclone-.*-windows-amd64.zip$' }
-       Invoke-WebRequest -Uri $WindowsAsset.browser_download_url -OutFile rclone.zip
-       Expand-Archive rclone.zip -DestinationPath . -Verbose
-       Get-ChildItem -Recurse -Include rclone.exe | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
+        $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/rclone/rclone/releases/tags/${{ env.RCLONE_VERSION }} -Headers $headers
+        $WindowsAsset = $release.assets | Where-Object { $_.name -cmatch '^rclone-.*-windows-amd64.zip$' }
+        Invoke-WebRequest -Uri $WindowsAsset.browser_download_url -OutFile rclone.zip
+        Expand-Archive rclone.zip -DestinationPath . -Verbose
+        Get-ChildItem -Recurse -Include rclone.exe | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
+        Move-Item rclone.exe rclone-win-x64.exe
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-rclone-windows
         if-no-files-found: error
         retention-days: 1
-        path: rclone.exe
+        path: rclone-win-x64.exe
 
   rclone-linux:
     runs-on: ubuntu-latest
@@ -283,29 +373,52 @@ jobs:
          "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
        }
 
-       $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/rclone/rclone/releases/tags/${{ env.RCLONE_VERSION }} -Headers $headers
-       $LinuxAsset = $release.assets | Where-Object { $_.name -cmatch '^rclone-.*-linux-amd64.zip$' }
-       Invoke-WebRequest -Uri $LinuxAsset.browser_download_url -OutFile rclone.zip
-       Expand-Archive rclone.zip -DestinationPath . -Verbose
-       Get-ChildItem -Recurse -Include rclone | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
+        $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/rclone/rclone/releases/tags/${{ env.RCLONE_VERSION }} -Headers $headers
+        $LinuxAsset = $release.assets | Where-Object { $_.name -cmatch '^rclone-.*-linux-amd64.zip$' }
+        Invoke-WebRequest -Uri $LinuxAsset.browser_download_url -OutFile rclone.zip
+        Expand-Archive rclone.zip -DestinationPath . -Verbose
+        Get-ChildItem -Recurse -Include rclone | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
+        Move-Item rclone rclone-linux-x64
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-rclone-linux
         if-no-files-found: error
         retention-days: 1
-        path: rclone
+        path: rclone-linux-x64
+
+  rclone-osx-arm64:
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+       $headers = @{
+         "User-Agent" = "GitHub Actions"
+         "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
+       }
+
+       $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/rclone/rclone/releases/tags/${{ env.RCLONE_VERSION }} -Headers $headers
+       $MacAsset = $release.assets | Where-Object { $_.name -cmatch '^rclone-.*-osx-arm64.zip$' }
+       Invoke-WebRequest -Uri $MacAsset.browser_download_url -OutFile rclone.zip
+       Expand-Archive rclone.zip -DestinationPath . -Verbose
+       Get-ChildItem -Recurse -Include rclone | Foreach-Object { Move-Item -LiteralPath $_ -Destination rclone-osx-arm64 }
+    - uses: actions/upload-artifact@v7
+      with:
+        name: binaries-rclone-osx-arm64
+        if-no-files-found: error
+        retention-days: 1
+        path: rclone-osx-arm64
 
   magick-windows:
     runs-on: ubuntu-latest
     steps:
     - run: Invoke-WebRequest -Uri 'https://imagemagick.org/archive/binaries/ImageMagick-${{ env.IMAGEMAGICK_VERSION }}-portable-Q16-HDRI-x64.7z' -OutFile ImageMagick.7z
     - run: 7z x ImageMagick.7z
+    - run: Move-Item magick.exe magick-win-x64.exe
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-imagemagick-windows
         if-no-files-found: error
         retention-days: 1
-        path: magick.exe
+        path: magick-win-x64.exe
 
 
 

--- a/scripts/Get-LatestImageMagickVersion.ps1
+++ b/scripts/Get-LatestImageMagickVersion.ps1
@@ -1,0 +1,213 @@
+[CmdletBinding()]
+param(
+    [string]$WorkflowPath = ".github\workflows\ci.yml",
+    [string[]]$Variables,
+    [switch]$WhatIf
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Invoke-GitHubApi {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Uri
+    )
+
+    $headers = @{
+        "User-Agent" = "prebuilt-version-updater"
+        "Accept" = "application/vnd.github+json"
+    }
+
+    Invoke-RestMethod -Method Get -Uri $Uri -Headers $headers
+}
+
+function Get-ReleaseTag {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Repository,
+        [switch]$TrimV
+    )
+
+    $response = Invoke-GitHubApi -Uri "https://api.github.com/repos/$Repository/releases/latest"
+    $tag = "$($response.tag_name)".Trim()
+    if ([string]::IsNullOrWhiteSpace($tag)) {
+        throw "Unable to get latest release tag for '$Repository'."
+    }
+
+    if ($TrimV) {
+        return $tag.TrimStart("v", "V")
+    }
+
+    return $tag
+}
+
+function Get-ZopfliVersion {
+    $tags = Invoke-GitHubApi -Uri "https://api.github.com/repos/google/zopfli/tags?per_page=50"
+    $versions =
+        foreach ($tag in $tags) {
+            if ($tag.name -match "^zopfli-(?<version>\d+\.\d+\.\d+)$") {
+                [PSCustomObject]@{
+                    Version = [version]$Matches["version"]
+                    Text = $Matches["version"]
+                }
+            }
+        }
+
+    if (-not $versions) {
+        throw "Unable to determine latest Zopfli version."
+    }
+
+    return ($versions | Sort-Object Version -Descending | Select-Object -First 1).Text
+}
+
+function Get-FFmpegVersion {
+    $release = Invoke-GitHubApi -Uri "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest"
+    $assets = @($release.assets)
+    if (-not $assets) {
+        throw "Unable to determine FFmpeg version (release has no assets)."
+    }
+
+    $requiredPatterns = @(
+        "^ffmpeg-.*-win64-gpl-(?<version>\d+(?:\.\d+){1,2})\.zip$",
+        "^ffmpeg-.*-winarm64-gpl-(?<version>\d+(?:\.\d+){1,2})\.zip$",
+        "^ffmpeg-.*-linux64-gpl-(?<version>\d+(?:\.\d+){1,2})\.tar\.xz$",
+        "^ffmpeg-.*-linuxarm64-gpl-(?<version>\d+(?:\.\d+){1,2})\.tar\.xz$"
+    )
+
+    $versionCounts = @{}
+    foreach ($asset in $assets) {
+        foreach ($pattern in $requiredPatterns) {
+            if ($asset.name -cmatch $pattern) {
+                $version = $Matches["version"]
+                if (-not $versionCounts.ContainsKey($version)) {
+                    $versionCounts[$version] = 0
+                }
+
+                $versionCounts[$version]++
+            }
+        }
+    }
+
+    $candidateVersions =
+        foreach ($entry in $versionCounts.GetEnumerator()) {
+            if ($entry.Value -ge $requiredPatterns.Count) {
+                [PSCustomObject]@{
+                    Version = [version]$entry.Key
+                    Text = $entry.Key
+                }
+            }
+        }
+
+    if (-not $candidateVersions) {
+        throw "Unable to determine FFmpeg version from latest FFmpeg-Builds release assets."
+    }
+
+    return ($candidateVersions | Sort-Object Version -Descending | Select-Object -First 1).Text
+}
+
+function Set-YamlVariableValue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Content,
+        [Parameter(Mandatory = $true)]
+        [string]$VariableName,
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    $pattern = "(?m)^(?<indent>[ \t]*)$([regex]::Escape($VariableName)):[ \t]*(?:(?<quoted>""(?<quotedValue>[^""]*)"")|(?<bare>[^\s#]+))(?<comment>[ \t]*#.*)?$"
+    $match = [regex]::Match($Content, $pattern)
+    if (-not $match.Success) {
+        return [PSCustomObject]@{
+            Found = $false
+            PreviousValue = $null
+            CurrentValue = $Value
+            Content = $Content
+        }
+    }
+
+    $quoted = $match.Groups["quoted"].Success
+    $existingValue = if ($quoted) { $match.Groups["quotedValue"].Value } else { $match.Groups["bare"].Value }
+    $comment = if ($match.Groups["comment"].Success) { $match.Groups["comment"].Value } else { "" }
+    $indent = $match.Groups["indent"].Value
+    $replacementValue = if ($quoted) { "`"$Value`"" } else { $Value }
+    $replacement = "$indent${VariableName}: $replacementValue$comment"
+    $updatedContent = [regex]::Replace($Content, $pattern, [System.Text.RegularExpressions.MatchEvaluator]{ param($m) $replacement }, 1)
+
+    return [PSCustomObject]@{
+        Found = $true
+        PreviousValue = $existingValue
+        CurrentValue = $Value
+        Content = $updatedContent
+    }
+}
+
+$resolvedWorkflowPath = Resolve-Path -LiteralPath $WorkflowPath
+$workflowContent = Get-Content -LiteralPath $resolvedWorkflowPath -Raw
+if ([string]::IsNullOrEmpty($workflowContent)) {
+    throw "Workflow file '$($resolvedWorkflowPath.Path)' is empty."
+}
+
+$availableLatestVersions = [ordered]@{
+    "ZOPFLI_VERSION" = Get-ZopfliVersion
+    "OXIPNG_VERSION" = Get-ReleaseTag -Repository "shssoichiro/oxipng" -TrimV
+    "FFMPEG_VERSION" = Get-FFmpegVersion
+    "RCLONE_VERSION" = Get-ReleaseTag -Repository "rclone/rclone"
+    "IMAGEMAGICK_VERSION" = Get-ReleaseTag -Repository "ImageMagick/ImageMagick" -TrimV
+}
+
+$selectedVariableNames =
+    if ($Variables -and $Variables.Count -gt 0) {
+        @($Variables)
+    } else {
+        @($availableLatestVersions.Keys)
+    }
+
+$latestVersions = [ordered]@{}
+foreach ($name in $selectedVariableNames) {
+    if (-not $availableLatestVersions.Contains($name)) {
+        $supported = ($availableLatestVersions.Keys -join ", ")
+        throw "Unsupported variable '$name'. Supported values: $supported"
+    }
+
+    $latestVersions[$name] = $availableLatestVersions[$name]
+}
+
+$updates = @()
+$updatedWorkflowContent = $workflowContent
+foreach ($entry in $latestVersions.GetEnumerator()) {
+    $result = Set-YamlVariableValue -Content $updatedWorkflowContent -VariableName $entry.Key -Value $entry.Value
+    if (-not $result.Found) {
+        throw "Variable '$($entry.Key)' was not found in '$($resolvedWorkflowPath.Path)'."
+    }
+
+    $updatedWorkflowContent = $result.Content
+    $updates += [PSCustomObject]@{
+        Variable = $entry.Key
+        PreviousValue = $result.PreviousValue
+        CurrentValue = $result.CurrentValue
+        Changed = $result.PreviousValue -cne $result.CurrentValue
+    }
+}
+
+$changed = $updates | Where-Object Changed
+if (-not $WhatIf) {
+    Set-Content -LiteralPath $resolvedWorkflowPath -Value $updatedWorkflowContent -NoNewline
+}
+
+foreach ($update in $updates) {
+    if ($update.Changed) {
+        Write-Output "$($update.Variable): $($update.PreviousValue) -> $($update.CurrentValue)"
+    } else {
+        Write-Output "$($update.Variable): up-to-date ($($update.CurrentValue))"
+    }
+}
+
+if ($WhatIf) {
+    Write-Output "WhatIf: no files were written."
+} elseif ($changed.Count -eq 0) {
+    Write-Output "No changes were needed."
+} else {
+    Write-Output "Updated '$($resolvedWorkflowPath.Path)' with latest versions."
+}


### PR DESCRIPTION
This change reduces manual maintenance in the release workflow by automating dependency version refreshes and standardizing produced binary names across platforms.

It also adds macOS arm64 outputs (M1+) so releases include first-class Apple Silicon binaries where upstream assets or build paths are available.

## What changed
- Added `scripts/Get-LatestImageMagickVersion.ps1`, now a generalized workflow updater that:
  - fetches latest versions for `ZOPFLI_VERSION`, `OXIPNG_VERSION`, `FFMPEG_VERSION`, `RCLONE_VERSION`, and `IMAGEMAGICK_VERSION`
  - updates `.github/workflows/ci.yml` in place
  - supports dry-run (`-WhatIf`) and targeted variable updates (`-Variables`)
- Updated `.github/workflows/ci.yml` artifact naming to `binaryname-os-arch[.exe]`.
  - examples: `ffmpeg-win-x64.exe`, `ffmpeg-win-arm64.exe`, `ffmpeg-linux-arm64`, `ffmpeg-osx-arm64`
- Added macOS arm64 jobs/artifacts:
  - `zopflipng-osx-arm64`
  - `oxipng-osx-arm64`
  - `ffmpeg-osx-arm64`
  - `rclone-osx-arm64`
- Updated `create-release.needs` to include the new macOS jobs.

## Notes for reviewers
- ImageMagick itself is still Windows-only in this workflow because there is no official portable macOS binary distribution analogous to the Windows archive currently used.
- FFmpeg macOS arm64 artifact is produced on `macos-14` using Homebrew to provide native arm64 `ffmpeg`/`ffprobe` binaries.

## Expected impact
- Fewer manual version bumps in CI workflow maintenance.
- Consistent artifact naming across OS/architecture.
- Expanded release coverage for macOS Apple Silicon users.