### PR TITLE
Add macOS arm64 PNGOUT artifact to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       ffmpeg-osx-arm64,
       pngout-linux,
       pngout-windows,
+      pngout-osx-arm64,
       rclone-windows,
       rclone-linux,
       rclone-osx-arm64,
@@ -219,6 +220,25 @@ jobs:
         if-no-files-found: error
         retention-days: 1
         path: pngout-linux-x64
+
+  pngout-osx-arm64:
+    runs-on: ubuntu-latest
+    steps:
+    - run: Invoke-WebRequest -Uri 'https://www.jonof.id.au/files/kenutils/pngout-20230322-mac.zip' -OutFile pngout.zip
+    - run: |
+        Expand-Archive pngout.zip -DestinationPath . -Force
+        $pngout = Get-ChildItem -Path "." -Recurse -File -Filter "pngout" | Select-Object -First 1
+        if (-not $pngout) {
+          throw "pngout binary not found in macOS archive"
+        }
+
+        Move-Item -LiteralPath $pngout.FullName -Destination "./pngout-osx-arm64"
+    - uses: actions/upload-artifact@v7
+      with:
+        name: binaries-pngout-osx-arm64
+        if-no-files-found: error
+        retention-days: 1
+        path: pngout-osx-arm64
 
   ffmpeg-windows:
     runs-on: ubuntu-latest
@@ -419,7 +439,6 @@ jobs:
         if-no-files-found: error
         retention-days: 1
         path: magick-win-x64.exe
-
 
 
 


### PR DESCRIPTION
This change completes macOS coverage for the PNG optimization tools shipped in releases by adding the missing PNGOUT macOS artifact.

## What changed
- Added a new `pngout-osx-arm64` job in `.github/workflows/ci.yml`.
- The job downloads `pngout-20230322-mac.zip` from JonoF kenutils, extracts the `pngout` binary, and publishes it as `pngout-osx-arm64`.
- Added `pngout-osx-arm64` to `create-release.needs` so release creation waits for and includes this artifact.

## Notes
- `zopfli` and `oxipng` macOS arm64 jobs already existed and were left unchanged.
- The source archive is a universal macOS build, but we keep the artifact naming aligned with the existing `*-osx-arm64` convention in this repository.