### PR TITLE
Add FFmpeg GHCR images for Linux x64 and arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,8 +351,16 @@ jobs:
          brew install ffmpeg
        }
 
-       Copy-Item (Get-Command ffmpeg).Source ffmpeg-osx-arm64
-       Copy-Item (Get-Command ffprobe).Source ffprobe-osx-arm64
+       $ffmpegCommand = Get-Command ffmpeg -ErrorAction Stop
+       $ffprobeCommand = Get-Command ffprobe -ErrorAction Stop
+
+       $ffmpegVersion = & $ffmpegCommand.Source -version | Select-Object -First 1
+       $ffprobeVersion = & $ffprobeCommand.Source -version | Select-Object -First 1
+       Write-Host "Installed $ffmpegVersion"
+       Write-Host "Installed $ffprobeVersion"
+
+       Copy-Item $ffmpegCommand.Source ffmpeg-osx-arm64
+       Copy-Item $ffprobeCommand.Source ffprobe-osx-arm64
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-osx-arm64
@@ -361,6 +369,95 @@ jobs:
         path: |
            ffmpeg-osx-arm64
            ffprobe-osx-arm64
+
+  ffmpeg-docker-linux-x64:
+    runs-on: ubuntu-latest
+    needs: [ffmpeg-linux]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/download-artifact@v8
+      with:
+        name: binaries-ffmpeg-linux
+        path: .
+    - run: |
+       @"
+       FROM scratch
+       COPY --chmod=0755 ffmpeg-linux-x64 /usr/local/bin/ffmpeg
+       COPY --chmod=0755 ffprobe-linux-x64 /usr/local/bin/ffprobe
+       ENTRYPOINT ["/usr/local/bin/ffmpeg"]
+       "@ | Set-Content -LiteralPath Dockerfile -NoNewline
+    - uses: docker/setup-buildx-action@v3
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/prebuilt-ffmpeg:${{ env.FFMPEG_VERSION }}-linux-x64
+
+  ffmpeg-docker-linux-arm64:
+    runs-on: ubuntu-latest
+    needs: [ffmpeg-linux-arm64]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/download-artifact@v8
+      with:
+        name: binaries-ffmpeg-linux-arm64
+        path: .
+    - run: |
+       @"
+       FROM scratch
+       COPY --chmod=0755 ffmpeg-linux-arm64 /usr/local/bin/ffmpeg
+       COPY --chmod=0755 ffprobe-linux-arm64 /usr/local/bin/ffprobe
+       ENTRYPOINT ["/usr/local/bin/ffmpeg"]
+       "@ | Set-Content -LiteralPath Dockerfile -NoNewline
+    - uses: docker/setup-buildx-action@v3
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/arm64
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/prebuilt-ffmpeg:${{ env.FFMPEG_VERSION }}-linux-arm64
+
+  ffmpeg-docker-manifest:
+    runs-on: ubuntu-latest
+    needs: [ffmpeg-docker-linux-x64, ffmpeg-docker-linux-arm64]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: docker/setup-buildx-action@v3
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - run: |
+       $registry = "ghcr.io/${{ github.repository_owner }}/prebuilt-ffmpeg"
+       docker buildx imagetools create `
+         --tag "$registry:${{ env.FFMPEG_VERSION }}" `
+         --tag "$registry:latest" `
+         "$registry:${{ env.FFMPEG_VERSION }}-linux-x64" `
+         "$registry:${{ env.FFMPEG_VERSION }}-linux-arm64"
+       docker buildx imagetools inspect "$registry:${{ env.FFMPEG_VERSION }}"
 
   rclone-windows:
     runs-on: ubuntu-latest
@@ -439,8 +536,6 @@ jobs:
         if-no-files-found: error
         retention-days: 1
         path: magick-win-x64.exe
-
-
 
 
 


### PR DESCRIPTION
## Why
We already publish FFmpeg binaries, but there was no container image output for Linux consumers. This adds CI publishing to GHCR so FFmpeg can be consumed directly as a small image for both amd64 and arm64.

## What changed
- Added `ffmpeg-docker-linux-x64` and `ffmpeg-docker-linux-arm64` jobs in `.github/workflows/ci.yml`.
- Each job downloads the existing FFmpeg binary artifacts, builds a Docker image from a `scratch` base, and pushes an architecture-specific tag to GHCR.
- Added `ffmpeg-docker-manifest` to publish multi-arch tags:
  - `ghcr.io/${{ github.repository_owner }}/prebuilt-ffmpeg:${{ env.FFMPEG_VERSION }}`
  - `ghcr.io/${{ github.repository_owner }}/prebuilt-ffmpeg:latest`
- Kept existing macOS Homebrew flow and added logging of installed `ffmpeg` and `ffprobe` versions in the `ffmpeg-osx-arm64` job.

## Notes
- Docker publishing jobs run on push to `main` and use `packages: write` with `GITHUB_TOKEN`.
- The images include both `ffmpeg` and `ffprobe`, with `ffmpeg` as entrypoint.