### PR TITLE
Fix ffmpeg Docker manifest tags in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,11 +453,11 @@ jobs:
     - run: |
        $registry = "ghcr.io/${{ github.repository_owner }}/prebuilt-ffmpeg"
        docker buildx imagetools create `
-         --tag "$registry:${{ env.FFMPEG_VERSION }}" `
-         --tag "$registry:latest" `
-         "$registry:${{ env.FFMPEG_VERSION }}-linux-x64" `
-         "$registry:${{ env.FFMPEG_VERSION }}-linux-arm64"
-       docker buildx imagetools inspect "$registry:${{ env.FFMPEG_VERSION }}"
+         --tag "${registry}:${{ env.FFMPEG_VERSION }}" `
+         --tag "${registry}:latest" `
+         "${registry}:${{ env.FFMPEG_VERSION }}-linux-x64" `
+         "${registry}:${{ env.FFMPEG_VERSION }}-linux-arm64"
+       docker buildx imagetools inspect "${registry}:${{ env.FFMPEG_VERSION }}"
 
   rclone-windows:
     runs-on: ubuntu-latest
@@ -536,6 +536,5 @@ jobs:
         if-no-files-found: error
         retention-days: 1
         path: magick-win-x64.exe
-
 
 


### PR DESCRIPTION
The main branch CI is failing in `ffmpeg-docker-manifest` because the PowerShell strings building image tags use `$registry:...`, which is parsed as scoped variable syntax and produces invalid Docker references.

This change switches those tag strings to `${registry}:...` in the `docker buildx imagetools create` and `inspect` commands. That keeps the existing workflow behavior but generates valid image references for versioned and `latest` manifest tags.