### PR TITLE
Use evermeet static FFmpeg/FFprobe for macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,24 +393,32 @@ jobs:
     runs-on: macos-14
     steps:
     - run: |
-       if (-not (Get-Command ffmpeg -ErrorAction SilentlyContinue)) {
-         brew install ffmpeg
+       Invoke-WebRequest -Uri "https://evermeet.cx/ffmpeg/ffmpeg-${{ env.FFMPEG_VERSION }}.zip" -OutFile ffmpeg.zip
+       Invoke-WebRequest -Uri "https://evermeet.cx/ffmpeg/ffprobe-${{ env.FFMPEG_VERSION }}.zip" -OutFile ffprobe.zip
+
+       Expand-Archive ffmpeg.zip -DestinationPath ffmpeg-extract -Force
+       Expand-Archive ffprobe.zip -DestinationPath ffprobe-extract -Force
+
+       $ffmpegBinary = Get-ChildItem -Path ffmpeg-extract -Recurse -File -Filter ffmpeg | Select-Object -First 1
+       if (-not $ffmpegBinary) {
+         throw "ffmpeg binary not found in evermeet archive"
        }
 
-       if (-not (Get-Command ffprobe -ErrorAction SilentlyContinue)) {
-         brew install ffmpeg
+       $ffprobeBinary = Get-ChildItem -Path ffprobe-extract -Recurse -File -Filter ffprobe | Select-Object -First 1
+       if (-not $ffprobeBinary) {
+         throw "ffprobe binary not found in evermeet archive"
        }
 
-       $ffmpegCommand = Get-Command ffmpeg -ErrorAction Stop
-       $ffprobeCommand = Get-Command ffprobe -ErrorAction Stop
+       Move-Item -LiteralPath $ffmpegBinary.FullName -Destination ffmpeg-osx-arm64
+       Move-Item -LiteralPath $ffprobeBinary.FullName -Destination ffprobe-osx-arm64
 
-       $ffmpegVersion = & $ffmpegCommand.Source -version | Select-Object -First 1
-       $ffprobeVersion = & $ffprobeCommand.Source -version | Select-Object -First 1
+       chmod +x ffmpeg-osx-arm64
+       chmod +x ffprobe-osx-arm64
+
+       $ffmpegVersion = & ./ffmpeg-osx-arm64 -version | Select-Object -First 1
+       $ffprobeVersion = & ./ffprobe-osx-arm64 -version | Select-Object -First 1
        Write-Host "Installed $ffmpegVersion"
        Write-Host "Installed $ffprobeVersion"
-
-       Copy-Item $ffmpegCommand.Source ffmpeg-osx-arm64
-       Copy-Item $ffprobeCommand.Source ffprobe-osx-arm64
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-osx-arm64


### PR DESCRIPTION
The macOS FFmpeg job currently depends on Homebrew, which adds an extra package-manager dependency for binaries we only need to publish as artifacts. This switches that job to download static release binaries directly from evermeet instead.

## What changed
- Replaced `brew install ffmpeg` logic in `ffmpeg-osx-arm64` with direct downloads of:
  - `https://evermeet.cx/ffmpeg/ffmpeg-${{ env.FFMPEG_VERSION }}.zip`
  - `https://evermeet.cx/ffmpeg/ffprobe-${{ env.FFMPEG_VERSION }}.zip`
- Extracted each archive, located the expected binary, and failed explicitly if a binary is missing.
- Moved binaries to the existing artifact names (`ffmpeg-osx-arm64`, `ffprobe-osx-arm64`) and kept upload behavior unchanged.
- Logged installed versions from the downloaded binaries.

## Notes
- This uses evermeet **release** artifacts so it stays aligned with the existing `FFMPEG_VERSION` pin used across platforms.
- Linux and Windows FFmpeg jobs are unchanged.