### PR TITLE
Retry create-release artifact downloads in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,17 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/download-artifact@v8
+    - id: download_release_artifacts
+      continue-on-error: true
+      uses: actions/download-artifact@v8
+      with:
+        pattern: '*'
+        path: binaries
+        merge-multiple: true
+    - if: steps.download_release_artifacts.outcome == 'failure'
+      run: Remove-Item -LiteralPath binaries -Recurse -Force -ErrorAction SilentlyContinue
+    - if: steps.download_release_artifacts.outcome == 'failure'
+      uses: actions/download-artifact@v8
       with:
         pattern: '*'
         path: binaries


### PR DESCRIPTION
Transient artifact blob download failures in GitHub Actions can make the `create-release` job fail even when upstream build jobs completed successfully. This change makes release creation more resilient to that intermittent failure mode.

## What changed
- Updated `create-release` in `.github/workflows/ci.yml` to make the first `actions/download-artifact@v8` attempt non-fatal.
- If that first attempt fails, the workflow removes the partially populated `binaries` directory and retries the same download once.
- The release creation step remains unchanged and still fails if artifacts are ultimately unavailable.

## Notes
- This is intentionally scoped to the `create-release` job where all artifacts are aggregated (`pattern: '*'`) and the transient failure was observed.