### PR TITLE
Run create-release job on PRs without publishing releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
       rclone-osx-arm64,
       magick-windows
     ]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
     steps:
@@ -76,7 +75,8 @@ jobs:
         pattern: '*'
         path: binaries
         merge-multiple: true
-    - run: 'gh release create "${{ env.VERSION }}" --target "${{ github.sha }}" ./binaries/*'
+    - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: 'gh release create "${{ env.VERSION }}" --target "${{ github.sha }}" ./binaries/*'
       env:
         GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Why
The release workflow was only exercised on pushes to `main`, so issues in the `create-release` job could go unnoticed during pull request validation.

## What changed
- Removed the job-level condition from `create-release` so the job executes during PR runs.
- Added the same `push` + `main` condition directly on the `gh release create` step.

## Result
PRs now validate the `create-release` job end-to-end (artifact download and step wiring), while actual GitHub release creation remains restricted to pushes on `main`.