### PR TITLE
Build Docker images in PR CI without publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,7 +495,6 @@ jobs:
   prebuilt-docker-linux-x64:
     runs-on: ubuntu-latest
     needs: [zopflipng-linux, oxipng-linux, pngout-linux, ffmpeg-linux, rclone-linux]
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     permissions:
       contents: read
       packages: write
@@ -549,7 +548,6 @@ jobs:
   prebuilt-docker-linux-arm64:
     runs-on: ubuntu-latest
     needs: [zopflipng-linux-arm64, oxipng-linux-arm64, pngout-linux-arm64, ffmpeg-linux-arm64, rclone-linux-arm64]
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,7 +495,7 @@ jobs:
   prebuilt-docker-linux-x64:
     runs-on: ubuntu-latest
     needs: [zopflipng-linux, oxipng-linux, pngout-linux, ffmpeg-linux, rclone-linux]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     permissions:
       contents: read
       packages: write
@@ -532,7 +532,8 @@ jobs:
        COPY --chmod=0755 rclone-linux-x64 /usr/local/bin/rclone
        "@ | Set-Content -LiteralPath Dockerfile -NoNewline
     - uses: docker/setup-buildx-action@v4
-    - uses: docker/login-action@v4
+    - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -542,13 +543,13 @@ jobs:
         context: .
         file: ./Dockerfile
         platforms: linux/amd64
-        push: true
+        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         tags: ghcr.io/${{ github.repository_owner }}/prebuilt:${{ env.VERSION }}-linux-x64
 
   prebuilt-docker-linux-arm64:
     runs-on: ubuntu-latest
     needs: [zopflipng-linux-arm64, oxipng-linux-arm64, pngout-linux-arm64, ffmpeg-linux-arm64, rclone-linux-arm64]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     permissions:
       contents: read
       packages: write
@@ -585,7 +586,8 @@ jobs:
        COPY --chmod=0755 rclone-linux-arm64 /usr/local/bin/rclone
        "@ | Set-Content -LiteralPath Dockerfile -NoNewline
     - uses: docker/setup-buildx-action@v4
-    - uses: docker/login-action@v4
+    - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -595,7 +597,7 @@ jobs:
         context: .
         file: ./Dockerfile
         platforms: linux/arm64
-        push: true
+        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         tags: ghcr.io/${{ github.repository_owner }}/prebuilt:${{ env.VERSION }}-linux-arm64
 
   prebuilt-docker-manifest:


### PR DESCRIPTION
## Why
Docker image jobs only ran on pushes to `main`, so pull requests could not catch Docker build regressions before merge. We want PR validation for Docker images while keeping publish behavior unchanged.

## What changed
- Run `prebuilt-docker-linux-x64` and `prebuilt-docker-linux-arm64` on `pull_request` as well as pushes to `main`.
- Run `docker/login-action` only for pushes to `main`.
- Make `docker/build-push-action` push conditionally only on pushes to `main`, so PRs build but do not publish.

## Notes
- `prebuilt-docker-manifest` remains gated to pushes on `main`, so release publishing flow is unchanged.