### PR TITLE
Build FFmpeg from source for Linux and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,6 +530,7 @@ jobs:
        $ffprobeVersion = & ./ffprobe-linux-x64 -version | Select-Object -First 1
        Write-Host "Built $ffmpegVersion"
        Write-Host "Built $ffprobeVersion"
+      shell: pwsh
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-linux
@@ -628,6 +629,7 @@ jobs:
        $ffprobeVersion = & ./ffprobe-linux-arm64 -version | Select-Object -First 1
        Write-Host "Built $ffmpegVersion"
        Write-Host "Built $ffprobeVersion"
+      shell: pwsh
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-linux-arm64
@@ -712,6 +714,7 @@ jobs:
        $ffprobeVersion = & ./ffprobe-osx-arm64 -version | Select-Object -First 1
        Write-Host "Built $ffmpegVersion"
        Write-Host "Built $ffprobeVersion"
+      shell: pwsh
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-osx-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ env:
   FFMPEG_MACOS_MAKE_JOBS: "4"
   # GPL profile. Nonfree options (for example libfdk-aac) are intentionally excluded.
   FFMPEG_WINDOWS_CONFIGURE_FLAGS: >-
-    --disable-doc --disable-debug --enable-pthreads --enable-runtime-cpudetect
+    --disable-doc --disable-debug --disable-pthreads --enable-w32threads --enable-runtime-cpudetect
     --enable-gpl --disable-nonfree --disable-shared --enable-static --disable-autodetect --pkg-config-flags=--static
     --enable-libopus --enable-libaom --enable-libjxl --enable-libsvtav1
     --disable-xlib --disable-libxcb --disable-libxcb-shm --disable-libxcb-xfixes --disable-libxcb-shape

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,15 @@ env:
   PNGOUT_VERSION: 1.0.0 # http://advsys.net/ken/utils.htm#pngout - manual version
   ZOPFLI_VERSION: "1.0.3" # https://github.com/google/zopfli/tags
   OXIPNG_VERSION: "10.1.1" # https://github.com/shssoichiro/oxipng/releases
-  FFMPEG_VERSION: "8.1" # https://github.com/BtbN/FFmpeg-Builds/releases
-  FFMPEG_MACOS_SOURCE_REF: "n8.1" # https://github.com/FFmpeg/FFmpeg/tags (keep aligned with FFMPEG_VERSION)
+  FFMPEG_VERSION: "8.1" # https://github.com/FFmpeg/FFmpeg/tags
+  FFMPEG_SOURCE_REF: "n8.1" # https://github.com/FFmpeg/FFmpeg/tags (keep aligned with FFMPEG_VERSION)
+  # GPL profile. Nonfree options (for example libfdk-aac) are intentionally excluded.
+  FFMPEG_LINUX_CONFIGURE_FLAGS: >-
+    --disable-doc --disable-debug --enable-pthreads --enable-runtime-cpudetect
+    --enable-gpl --disable-nonfree --disable-shared --enable-static --disable-autodetect --pkg-config-flags=--static
+    --enable-libopus --enable-libaom --enable-libjxl --enable-libsvtav1
+    --disable-xlib --disable-libxcb --disable-libxcb-shm --disable-libxcb-xfixes --disable-libxcb-shape
+  FFMPEG_LINUX_MAKE_JOBS: "4"
   # GPL profile. Nonfree options (for example libfdk-aac) are intentionally excluded.
   FFMPEG_MACOS_CONFIGURE_FLAGS: >-
     --arch=arm64 --target-os=darwin --disable-doc --disable-debug --enable-pthreads
@@ -25,6 +32,13 @@ env:
     --enable-libopus --enable-libaom --enable-libjxl --enable-libsvtav1
     --disable-xlib --disable-libxcb --disable-libxcb-shm --disable-libxcb-xfixes --disable-libxcb-shape
   FFMPEG_MACOS_MAKE_JOBS: "4"
+  # GPL profile. Nonfree options (for example libfdk-aac) are intentionally excluded.
+  FFMPEG_WINDOWS_CONFIGURE_FLAGS: >-
+    --disable-doc --disable-debug --enable-pthreads --enable-runtime-cpudetect
+    --enable-gpl --disable-nonfree --disable-shared --enable-static --disable-autodetect --pkg-config-flags=--static
+    --enable-libopus --enable-libaom --enable-libjxl --enable-libsvtav1
+    --disable-xlib --disable-libxcb --disable-libxcb-shm --disable-libxcb-xfixes --disable-libxcb-shape
+  FFMPEG_WINDOWS_MAKE_JOBS: "4"
   RCLONE_VERSION: "v1.73.5" # https://github.com/rclone/rclone/releases
   IMAGEMAGICK_VERSION: "7.1.2-21" # https://github.com/ImageMagick/ImageMagick/releases/latest
 
@@ -300,21 +314,60 @@ jobs:
         path: pngout-osx-arm64
 
   ffmpeg-windows:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: UCRT64
+        update: true
+        install: >-
+          base-devel
+          make
+          pkgconf
+          nasm
+          yasm
+          mingw-w64-ucrt-x86_64-gcc
+          mingw-w64-ucrt-x86_64-opus
+          mingw-w64-ucrt-x86_64-aom
+          mingw-w64-ucrt-x86_64-libjxl
+          mingw-w64-ucrt-x86_64-svt-av1
+    - shell: msys2 {0}
+      run: |
+        set -euo pipefail
+
+        curl -fsSL "https://github.com/FFmpeg/FFmpeg/archive/refs/tags/${{ env.FFMPEG_SOURCE_REF }}.tar.gz" -o ffmpeg.tar.gz
+        tar -xzf ffmpeg.tar.gz
+
+        source_directory="FFmpeg-${{ env.FFMPEG_SOURCE_REF }}"
+        if [[ ! -d "$source_directory" ]]; then
+          echo "ffmpeg source directory not found: $source_directory" >&2
+          exit 1
+        fi
+
+        cd "$source_directory"
+        ./configure --arch=x86_64 --target-os=mingw32 ${{ env.FFMPEG_WINDOWS_CONFIGURE_FLAGS }}
+        make -j${{ env.FFMPEG_WINDOWS_MAKE_JOBS }}
+
+        cp ./ffmpeg.exe ../ffmpeg-win-x64.exe
+        cp ./ffprobe.exe ../ffprobe-win-x64.exe
     - run: |
-       $headers = @{
-         "User-Agent" = "GitHub Actions"
-         "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
+       function Assert-ConfigureOptionEnabled([string]$option) {
+         $buildConfig = & ./ffmpeg-win-x64.exe -buildconf | Out-String
+         if ($buildConfig -notmatch [Regex]::Escape($option)) {
+           throw "Missing expected FFmpeg configure option: $option"
+         }
        }
 
-        $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest -Headers $headers
-        $WindowsAsset = $release.assets | Where-Object { $_.name -cmatch '^ffmpeg-.*-win64-gpl-${{ env.FFMPEG_VERSION }}.zip$' }
-        Invoke-WebRequest -Uri $WindowsAsset.browser_download_url -OutFile ffmpeg.zip
-        Expand-Archive ffmpeg.zip -DestinationPath . -Verbose
-        Get-ChildItem -Recurse -Include ffmpeg.exe, ffprobe.exe | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
-        Move-Item ffmpeg.exe ffmpeg-win-x64.exe
-        Move-Item ffprobe.exe ffprobe-win-x64.exe
+       Assert-ConfigureOptionEnabled "--enable-gpl"
+       Assert-ConfigureOptionEnabled "--enable-libopus"
+       Assert-ConfigureOptionEnabled "--enable-libaom"
+       Assert-ConfigureOptionEnabled "--enable-libjxl"
+       Assert-ConfigureOptionEnabled "--enable-libsvtav1"
+
+       $ffmpegVersion = & ./ffmpeg-win-x64.exe -version | Select-Object -First 1
+       $ffprobeVersion = & ./ffprobe-win-x64.exe -version | Select-Object -First 1
+       Write-Host "Built $ffmpegVersion"
+       Write-Host "Built $ffprobeVersion"
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-windows
@@ -325,21 +378,60 @@ jobs:
            ffprobe-win-x64.exe
 
   ffmpeg-windows-arm64:
-    runs-on: ubuntu-latest
+    runs-on: windows-11-arm
     steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: CLANGARM64
+        update: true
+        install: >-
+          base-devel
+          make
+          pkgconf
+          nasm
+          yasm
+          mingw-w64-clang-aarch64-clang
+          mingw-w64-clang-aarch64-opus
+          mingw-w64-clang-aarch64-aom
+          mingw-w64-clang-aarch64-libjxl
+          mingw-w64-clang-aarch64-svt-av1
+    - shell: msys2 {0}
+      run: |
+        set -euo pipefail
+
+        curl -fsSL "https://github.com/FFmpeg/FFmpeg/archive/refs/tags/${{ env.FFMPEG_SOURCE_REF }}.tar.gz" -o ffmpeg.tar.gz
+        tar -xzf ffmpeg.tar.gz
+
+        source_directory="FFmpeg-${{ env.FFMPEG_SOURCE_REF }}"
+        if [[ ! -d "$source_directory" ]]; then
+          echo "ffmpeg source directory not found: $source_directory" >&2
+          exit 1
+        fi
+
+        cd "$source_directory"
+        ./configure --arch=aarch64 --target-os=mingw32 --cc=clang --cxx=clang++ --enable-neon ${{ env.FFMPEG_WINDOWS_CONFIGURE_FLAGS }}
+        make -j${{ env.FFMPEG_WINDOWS_MAKE_JOBS }}
+
+        cp ./ffmpeg.exe ../ffmpeg-win-arm64.exe
+        cp ./ffprobe.exe ../ffprobe-win-arm64.exe
     - run: |
-       $headers = @{
-         "User-Agent" = "GitHub Actions"
-         "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
+       function Assert-ConfigureOptionEnabled([string]$option) {
+         $buildConfig = & ./ffmpeg-win-arm64.exe -buildconf | Out-String
+         if ($buildConfig -notmatch [Regex]::Escape($option)) {
+           throw "Missing expected FFmpeg configure option: $option"
+         }
        }
 
-        $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest -Headers $headers
-        $WindowsAsset = $release.assets | Where-Object { $_.name -cmatch '^ffmpeg-.*-winarm64-gpl-${{ env.FFMPEG_VERSION }}.zip$' }
-        Invoke-WebRequest -Uri $WindowsAsset.browser_download_url -OutFile ffmpeg.zip
-        Expand-Archive ffmpeg.zip -DestinationPath . -Verbose
-        Get-ChildItem -Recurse -Include ffmpeg.exe, ffprobe.exe | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
-        Move-Item ffmpeg.exe ffmpeg-win-arm64.exe
-        Move-Item ffprobe.exe ffprobe-win-arm64.exe
+       Assert-ConfigureOptionEnabled "--enable-gpl"
+       Assert-ConfigureOptionEnabled "--enable-libopus"
+       Assert-ConfigureOptionEnabled "--enable-libaom"
+       Assert-ConfigureOptionEnabled "--enable-libjxl"
+       Assert-ConfigureOptionEnabled "--enable-libsvtav1"
+
+       $ffmpegVersion = & ./ffmpeg-win-arm64.exe -version | Select-Object -First 1
+       $ffprobeVersion = & ./ffprobe-win-arm64.exe -version | Select-Object -First 1
+       Write-Host "Built $ffmpegVersion"
+       Write-Host "Built $ffprobeVersion"
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-windows-arm64
@@ -353,18 +445,91 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: |
-       $headers = @{
-         "User-Agent" = "GitHub Actions"
-         "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends build-essential pkg-config nasm yasm libopus-dev libaom-dev libjxl-dev libsvtav1-dev
+    - run: |
+       Invoke-WebRequest -Uri "https://github.com/FFmpeg/FFmpeg/archive/refs/tags/${{ env.FFMPEG_SOURCE_REF }}.tar.gz" -OutFile ffmpeg.tar.gz
+       tar -xzf ffmpeg.tar.gz
+
+       $sourceDirectory = "FFmpeg-${{ env.FFMPEG_SOURCE_REF }}"
+       if (-not (Test-Path -LiteralPath $sourceDirectory -PathType Container)) {
+         throw "ffmpeg source directory not found: $sourceDirectory"
        }
 
-        $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest -Headers $headers
-        $LinuxAsset = $release.assets | Where-Object { $_.name -cmatch '^ffmpeg-.*-linux64-gpl-${{ env.FFMPEG_VERSION }}.tar.xz$' }
-        Invoke-WebRequest -Uri $LinuxAsset.browser_download_url -OutFile ffmpeg.tar.xz
-        tar -xvf ffmpeg.tar.xz
-        Get-ChildItem -Recurse -Include ffmpeg, ffprobe | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
-        Move-Item ffmpeg ffmpeg-linux-x64
-        Move-Item ffprobe ffprobe-linux-x64
+       $configureFlags = @("--arch=x86_64", "--target-os=linux") + ("${{ env.FFMPEG_LINUX_CONFIGURE_FLAGS }}" -split '\s+' | Where-Object { $_ })
+       Push-Location $sourceDirectory
+       & ./configure @configureFlags
+       & make -j${{ env.FFMPEG_LINUX_MAKE_JOBS }}
+
+       Move-Item -LiteralPath ./ffmpeg -Destination ../ffmpeg-linux-x64
+       Move-Item -LiteralPath ./ffprobe -Destination ../ffprobe-linux-x64
+       Pop-Location
+
+       chmod +x ffmpeg-linux-x64
+       chmod +x ffprobe-linux-x64
+
+       function Get-ExternalDependencies([string]$path) {
+         $lddOutput = & ldd $path 2>&1
+         if ($LASTEXITCODE -ne 0 -and ($lddOutput -notmatch 'not a dynamic executable')) {
+           throw "Unable to inspect dependencies for '$path': $($lddOutput -join [Environment]::NewLine)"
+         }
+
+         if ($lddOutput -match 'not a dynamic executable') {
+           return @()
+         }
+
+         return $lddOutput | ForEach-Object {
+           if ($_ -match '=>\s+(?<dependency>/\S+)') {
+             $Matches['dependency']
+           } elseif ($_ -match '^\s*(?<dependency>/\S+)') {
+             $Matches['dependency']
+           }
+         } | Where-Object { $_ } | Sort-Object -Unique
+       }
+
+       $forbiddenDependencyPatterns = @('libxcb', 'libX11')
+       function Get-ForbiddenDependencies([string[]]$dependencies) {
+         return $dependencies | Where-Object {
+           $dependency = $_
+           $forbiddenDependencyPatterns | Where-Object { $dependency -match $_ }
+         }
+       }
+
+       $ffmpegExternalDependencies = Get-ExternalDependencies "./ffmpeg-linux-x64"
+       $ffmpegForbiddenDependencies = Get-ForbiddenDependencies $ffmpegExternalDependencies
+       if ($ffmpegForbiddenDependencies) {
+         throw "ffmpeg-linux-x64 has forbidden dependencies: $($ffmpegForbiddenDependencies -join ', ')"
+       }
+       if ($ffmpegExternalDependencies) {
+         Write-Host "ffmpeg-linux-x64 external dependencies: $($ffmpegExternalDependencies -join ', ')"
+       }
+
+       $ffprobeExternalDependencies = Get-ExternalDependencies "./ffprobe-linux-x64"
+       $ffprobeForbiddenDependencies = Get-ForbiddenDependencies $ffprobeExternalDependencies
+       if ($ffprobeForbiddenDependencies) {
+         throw "ffprobe-linux-x64 has forbidden dependencies: $($ffprobeForbiddenDependencies -join ', ')"
+       }
+       if ($ffprobeExternalDependencies) {
+         Write-Host "ffprobe-linux-x64 external dependencies: $($ffprobeExternalDependencies -join ', ')"
+       }
+
+       function Assert-ConfigureOptionEnabled([string]$option) {
+         $buildConfig = & ./ffmpeg-linux-x64 -buildconf | Out-String
+         if ($buildConfig -notmatch [Regex]::Escape($option)) {
+           throw "Missing expected FFmpeg configure option: $option"
+         }
+       }
+
+       Assert-ConfigureOptionEnabled "--enable-gpl"
+       Assert-ConfigureOptionEnabled "--enable-libopus"
+       Assert-ConfigureOptionEnabled "--enable-libaom"
+       Assert-ConfigureOptionEnabled "--enable-libjxl"
+       Assert-ConfigureOptionEnabled "--enable-libsvtav1"
+
+       $ffmpegVersion = & ./ffmpeg-linux-x64 -version | Select-Object -First 1
+       $ffprobeVersion = & ./ffprobe-linux-x64 -version | Select-Object -First 1
+       Write-Host "Built $ffmpegVersion"
+       Write-Host "Built $ffprobeVersion"
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-linux
@@ -375,20 +540,94 @@ jobs:
            ffprobe-linux-x64
 
   ffmpeg-linux-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - run: |
-       $headers = @{
-         "User-Agent" = "GitHub Actions"
-         "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends build-essential pkg-config nasm yasm libopus-dev libaom-dev libjxl-dev libsvtav1-dev
+    - run: |
+       Invoke-WebRequest -Uri "https://github.com/FFmpeg/FFmpeg/archive/refs/tags/${{ env.FFMPEG_SOURCE_REF }}.tar.gz" -OutFile ffmpeg.tar.gz
+       tar -xzf ffmpeg.tar.gz
+
+       $sourceDirectory = "FFmpeg-${{ env.FFMPEG_SOURCE_REF }}"
+       if (-not (Test-Path -LiteralPath $sourceDirectory -PathType Container)) {
+         throw "ffmpeg source directory not found: $sourceDirectory"
        }
 
-        $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest -Headers $headers
-        $LinuxAsset = $release.assets | Where-Object { $_.name -cmatch '^ffmpeg-.*-linuxarm64-gpl-${{ env.FFMPEG_VERSION }}.tar.xz$' }
-        Invoke-WebRequest -Uri $LinuxAsset.browser_download_url -OutFile ffmpeg.tar.xz
-        tar -xvf ffmpeg.tar.xz
-        Get-ChildItem -Recurse -Filter ffmpeg | Foreach-Object { Move-Item -LiteralPath $_ -Destination ffmpeg-linux-arm64 }
-        Get-ChildItem -Recurse -Filter ffprobe | Foreach-Object { Move-Item -LiteralPath $_ -Destination ffprobe-linux-arm64 }
+       $configureFlags = @("--arch=aarch64", "--target-os=linux", "--enable-neon") + ("${{ env.FFMPEG_LINUX_CONFIGURE_FLAGS }}" -split '\s+' | Where-Object { $_ })
+       Push-Location $sourceDirectory
+       & ./configure @configureFlags
+       & make -j${{ env.FFMPEG_LINUX_MAKE_JOBS }}
+
+       Move-Item -LiteralPath ./ffmpeg -Destination ../ffmpeg-linux-arm64
+       Move-Item -LiteralPath ./ffprobe -Destination ../ffprobe-linux-arm64
+       Pop-Location
+
+       chmod +x ffmpeg-linux-arm64
+       chmod +x ffprobe-linux-arm64
+
+       function Get-ExternalDependencies([string]$path) {
+         $lddOutput = & ldd $path 2>&1
+         if ($LASTEXITCODE -ne 0 -and ($lddOutput -notmatch 'not a dynamic executable')) {
+           throw "Unable to inspect dependencies for '$path': $($lddOutput -join [Environment]::NewLine)"
+         }
+
+         if ($lddOutput -match 'not a dynamic executable') {
+           return @()
+         }
+
+         return $lddOutput | ForEach-Object {
+           if ($_ -match '=>\s+(?<dependency>/\S+)') {
+             $Matches['dependency']
+           } elseif ($_ -match '^\s*(?<dependency>/\S+)') {
+             $Matches['dependency']
+           }
+         } | Where-Object { $_ } | Sort-Object -Unique
+       }
+
+       $forbiddenDependencyPatterns = @('libxcb', 'libX11')
+       function Get-ForbiddenDependencies([string[]]$dependencies) {
+         return $dependencies | Where-Object {
+           $dependency = $_
+           $forbiddenDependencyPatterns | Where-Object { $dependency -match $_ }
+         }
+       }
+
+       $ffmpegExternalDependencies = Get-ExternalDependencies "./ffmpeg-linux-arm64"
+       $ffmpegForbiddenDependencies = Get-ForbiddenDependencies $ffmpegExternalDependencies
+       if ($ffmpegForbiddenDependencies) {
+         throw "ffmpeg-linux-arm64 has forbidden dependencies: $($ffmpegForbiddenDependencies -join ', ')"
+       }
+       if ($ffmpegExternalDependencies) {
+         Write-Host "ffmpeg-linux-arm64 external dependencies: $($ffmpegExternalDependencies -join ', ')"
+       }
+
+       $ffprobeExternalDependencies = Get-ExternalDependencies "./ffprobe-linux-arm64"
+       $ffprobeForbiddenDependencies = Get-ForbiddenDependencies $ffprobeExternalDependencies
+       if ($ffprobeForbiddenDependencies) {
+         throw "ffprobe-linux-arm64 has forbidden dependencies: $($ffprobeForbiddenDependencies -join ', ')"
+       }
+       if ($ffprobeExternalDependencies) {
+         Write-Host "ffprobe-linux-arm64 external dependencies: $($ffprobeExternalDependencies -join ', ')"
+       }
+
+       function Assert-ConfigureOptionEnabled([string]$option) {
+         $buildConfig = & ./ffmpeg-linux-arm64 -buildconf | Out-String
+         if ($buildConfig -notmatch [Regex]::Escape($option)) {
+           throw "Missing expected FFmpeg configure option: $option"
+         }
+       }
+
+       Assert-ConfigureOptionEnabled "--enable-gpl"
+       Assert-ConfigureOptionEnabled "--enable-libopus"
+       Assert-ConfigureOptionEnabled "--enable-libaom"
+       Assert-ConfigureOptionEnabled "--enable-libjxl"
+       Assert-ConfigureOptionEnabled "--enable-libsvtav1"
+
+       $ffmpegVersion = & ./ffmpeg-linux-arm64 -version | Select-Object -First 1
+       $ffprobeVersion = & ./ffprobe-linux-arm64 -version | Select-Object -First 1
+       Write-Host "Built $ffmpegVersion"
+       Write-Host "Built $ffprobeVersion"
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-linux-arm64
@@ -404,10 +643,10 @@ jobs:
     - run: |
        brew install pkg-config opus aom jpeg-xl svt-av1
 
-       Invoke-WebRequest -Uri "https://github.com/FFmpeg/FFmpeg/archive/refs/tags/${{ env.FFMPEG_MACOS_SOURCE_REF }}.tar.gz" -OutFile ffmpeg.tar.gz
+       Invoke-WebRequest -Uri "https://github.com/FFmpeg/FFmpeg/archive/refs/tags/${{ env.FFMPEG_SOURCE_REF }}.tar.gz" -OutFile ffmpeg.tar.gz
        tar -xzf ffmpeg.tar.gz
 
-       $sourceDirectory = "FFmpeg-${{ env.FFMPEG_MACOS_SOURCE_REF }}"
+       $sourceDirectory = "FFmpeg-${{ env.FFMPEG_SOURCE_REF }}"
        if (-not (Test-Path -LiteralPath $sourceDirectory -PathType Container)) {
          throw "ffmpeg source directory not found: $sourceDirectory"
        }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,24 +350,30 @@ jobs:
 
         cp ./ffmpeg.exe ../ffmpeg-win-x64.exe
         cp ./ffprobe.exe ../ffprobe-win-x64.exe
-    - run: |
-       function Assert-ConfigureOptionEnabled([string]$option) {
-         $buildConfig = & ./ffmpeg-win-x64.exe -buildconf | Out-String
-         if ($buildConfig -notmatch [Regex]::Escape($option)) {
-           throw "Missing expected FFmpeg configure option: $option"
-         }
-       }
+    - shell: msys2 {0}
+      run: |
+        set -euo pipefail
 
-       Assert-ConfigureOptionEnabled "--enable-gpl"
-       Assert-ConfigureOptionEnabled "--enable-libopus"
-       Assert-ConfigureOptionEnabled "--enable-libaom"
-       Assert-ConfigureOptionEnabled "--enable-libjxl"
-       Assert-ConfigureOptionEnabled "--enable-libsvtav1"
+        assert_configure_option_enabled() {
+          local option="$1"
+          local build_config
+          build_config="$(./ffmpeg-win-x64.exe -buildconf)"
+          if ! grep -Fq -- "$option" <<<"$build_config"; then
+            echo "Missing expected FFmpeg configure option: $option" >&2
+            exit 1
+          fi
+        }
 
-       $ffmpegVersion = & ./ffmpeg-win-x64.exe -version | Select-Object -First 1
-       $ffprobeVersion = & ./ffprobe-win-x64.exe -version | Select-Object -First 1
-       Write-Host "Built $ffmpegVersion"
-       Write-Host "Built $ffprobeVersion"
+        assert_configure_option_enabled "--enable-gpl"
+        assert_configure_option_enabled "--enable-libopus"
+        assert_configure_option_enabled "--enable-libaom"
+        assert_configure_option_enabled "--enable-libjxl"
+        assert_configure_option_enabled "--enable-libsvtav1"
+
+        ffmpeg_version="$(./ffmpeg-win-x64.exe -version | head -n 1)"
+        ffprobe_version="$(./ffprobe-win-x64.exe -version | head -n 1)"
+        echo "Built $ffmpeg_version"
+        echo "Built $ffprobe_version"
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-windows
@@ -414,24 +420,30 @@ jobs:
 
         cp ./ffmpeg.exe ../ffmpeg-win-arm64.exe
         cp ./ffprobe.exe ../ffprobe-win-arm64.exe
-    - run: |
-       function Assert-ConfigureOptionEnabled([string]$option) {
-         $buildConfig = & ./ffmpeg-win-arm64.exe -buildconf | Out-String
-         if ($buildConfig -notmatch [Regex]::Escape($option)) {
-           throw "Missing expected FFmpeg configure option: $option"
-         }
-       }
+    - shell: msys2 {0}
+      run: |
+        set -euo pipefail
 
-       Assert-ConfigureOptionEnabled "--enable-gpl"
-       Assert-ConfigureOptionEnabled "--enable-libopus"
-       Assert-ConfigureOptionEnabled "--enable-libaom"
-       Assert-ConfigureOptionEnabled "--enable-libjxl"
-       Assert-ConfigureOptionEnabled "--enable-libsvtav1"
+        assert_configure_option_enabled() {
+          local option="$1"
+          local build_config
+          build_config="$(./ffmpeg-win-arm64.exe -buildconf)"
+          if ! grep -Fq -- "$option" <<<"$build_config"; then
+            echo "Missing expected FFmpeg configure option: $option" >&2
+            exit 1
+          fi
+        }
 
-       $ffmpegVersion = & ./ffmpeg-win-arm64.exe -version | Select-Object -First 1
-       $ffprobeVersion = & ./ffprobe-win-arm64.exe -version | Select-Object -First 1
-       Write-Host "Built $ffmpegVersion"
-       Write-Host "Built $ffprobeVersion"
+        assert_configure_option_enabled "--enable-gpl"
+        assert_configure_option_enabled "--enable-libopus"
+        assert_configure_option_enabled "--enable-libaom"
+        assert_configure_option_enabled "--enable-libjxl"
+        assert_configure_option_enabled "--enable-libsvtav1"
+
+        ffmpeg_version="$(./ffmpeg-win-arm64.exe -version | head -n 1)"
+        ffprobe_version="$(./ffprobe-win-arm64.exe -version | head -n 1)"
+        echo "Built $ffmpeg_version"
+        echo "Built $ffprobe_version"
     - uses: actions/upload-artifact@v7
       with:
         name: binaries-ffmpeg-windows-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
   FFMPEG_LINUX_CONFIGURE_FLAGS: >-
     --disable-doc --disable-debug --enable-pthreads --enable-runtime-cpudetect
     --enable-gpl --disable-nonfree --disable-shared --enable-static --disable-autodetect --pkg-config-flags=--static
-    --enable-libopus --enable-libaom --enable-libjxl --enable-libsvtav1
+    --enable-libopus --enable-libaom --enable-libjxl
     --disable-xlib --disable-libxcb --disable-libxcb-shm --disable-libxcb-xfixes --disable-libxcb-shape
   FFMPEG_LINUX_MAKE_JOBS: "4"
   # GPL profile. Nonfree options (for example libfdk-aac) are intentionally excluded.
@@ -446,7 +446,7 @@ jobs:
     steps:
     - run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends build-essential pkg-config nasm yasm libopus-dev libaom-dev libjxl-dev libsvtav1-dev
+        sudo apt-get install -y --no-install-recommends build-essential pkg-config nasm yasm libopus-dev libaom-dev libjxl-dev
     - run: |
        Invoke-WebRequest -Uri "https://github.com/FFmpeg/FFmpeg/archive/refs/tags/${{ env.FFMPEG_SOURCE_REF }}.tar.gz" -OutFile ffmpeg.tar.gz
        tar -xzf ffmpeg.tar.gz
@@ -521,10 +521,9 @@ jobs:
        }
 
        Assert-ConfigureOptionEnabled "--enable-gpl"
-       Assert-ConfigureOptionEnabled "--enable-libopus"
-       Assert-ConfigureOptionEnabled "--enable-libaom"
-       Assert-ConfigureOptionEnabled "--enable-libjxl"
-       Assert-ConfigureOptionEnabled "--enable-libsvtav1"
+        Assert-ConfigureOptionEnabled "--enable-libopus"
+        Assert-ConfigureOptionEnabled "--enable-libaom"
+        Assert-ConfigureOptionEnabled "--enable-libjxl"
 
        $ffmpegVersion = & ./ffmpeg-linux-x64 -version | Select-Object -First 1
        $ffprobeVersion = & ./ffprobe-linux-x64 -version | Select-Object -First 1
@@ -545,7 +544,7 @@ jobs:
     steps:
     - run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends build-essential pkg-config nasm yasm libopus-dev libaom-dev libjxl-dev libsvtav1-dev
+        sudo apt-get install -y --no-install-recommends build-essential pkg-config nasm yasm libopus-dev libaom-dev libjxl-dev
     - run: |
        Invoke-WebRequest -Uri "https://github.com/FFmpeg/FFmpeg/archive/refs/tags/${{ env.FFMPEG_SOURCE_REF }}.tar.gz" -OutFile ffmpeg.tar.gz
        tar -xzf ffmpeg.tar.gz
@@ -620,10 +619,9 @@ jobs:
        }
 
        Assert-ConfigureOptionEnabled "--enable-gpl"
-       Assert-ConfigureOptionEnabled "--enable-libopus"
-       Assert-ConfigureOptionEnabled "--enable-libaom"
-       Assert-ConfigureOptionEnabled "--enable-libjxl"
-       Assert-ConfigureOptionEnabled "--enable-libsvtav1"
+        Assert-ConfigureOptionEnabled "--enable-libopus"
+        Assert-ConfigureOptionEnabled "--enable-libaom"
+        Assert-ConfigureOptionEnabled "--enable-libjxl"
 
        $ffmpegVersion = & ./ffmpeg-linux-arm64 -version | Select-Object -First 1
        $ffprobeVersion = & ./ffprobe-linux-arm64 -version | Select-Object -First 1

--- a/scripts/Get-LatestImageMagickVersion.ps1
+++ b/scripts/Get-LatestImageMagickVersion.ps1
@@ -62,48 +62,22 @@ function Get-ZopfliVersion {
 }
 
 function Get-FFmpegVersion {
-    $release = Invoke-GitHubApi -Uri "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest"
-    $assets = @($release.assets)
-    if (-not $assets) {
-        throw "Unable to determine FFmpeg version (release has no assets)."
-    }
-
-    $requiredPatterns = @(
-        "^ffmpeg-.*-win64-gpl-(?<version>\d+(?:\.\d+){1,2})\.zip$",
-        "^ffmpeg-.*-winarm64-gpl-(?<version>\d+(?:\.\d+){1,2})\.zip$",
-        "^ffmpeg-.*-linux64-gpl-(?<version>\d+(?:\.\d+){1,2})\.tar\.xz$",
-        "^ffmpeg-.*-linuxarm64-gpl-(?<version>\d+(?:\.\d+){1,2})\.tar\.xz$"
-    )
-
-    $versionCounts = @{}
-    foreach ($asset in $assets) {
-        foreach ($pattern in $requiredPatterns) {
-            if ($asset.name -cmatch $pattern) {
-                $version = $Matches["version"]
-                if (-not $versionCounts.ContainsKey($version)) {
-                    $versionCounts[$version] = 0
-                }
-
-                $versionCounts[$version]++
-            }
-        }
-    }
-
-    $candidateVersions =
-        foreach ($entry in $versionCounts.GetEnumerator()) {
-            if ($entry.Value -ge $requiredPatterns.Count) {
+    $tags = Invoke-GitHubApi -Uri "https://api.github.com/repos/FFmpeg/FFmpeg/tags?per_page=100"
+    $versions =
+        foreach ($tag in $tags) {
+            if ($tag.name -match "^n(?<version>\d+(?:\.\d+){1,2})$") {
                 [PSCustomObject]@{
-                    Version = [version]$entry.Key
-                    Text = $entry.Key
+                    Version = [version]$Matches["version"]
+                    Text = $Matches["version"]
                 }
             }
         }
 
-    if (-not $candidateVersions) {
-        throw "Unable to determine FFmpeg version from latest FFmpeg-Builds release assets."
+    if (-not $versions) {
+        throw "Unable to determine latest FFmpeg version from FFmpeg tags."
     }
 
-    return ($candidateVersions | Sort-Object Version -Descending | Select-Object -First 1).Text
+    return ($versions | Sort-Object Version -Descending | Select-Object -First 1).Text
 }
 
 function Set-YamlVariableValue {
@@ -149,10 +123,12 @@ if ([string]::IsNullOrEmpty($workflowContent)) {
     throw "Workflow file '$($resolvedWorkflowPath.Path)' is empty."
 }
 
+$latestFFmpegVersion = Get-FFmpegVersion
 $availableLatestVersions = [ordered]@{
     "ZOPFLI_VERSION" = Get-ZopfliVersion
     "OXIPNG_VERSION" = Get-ReleaseTag -Repository "shssoichiro/oxipng" -TrimV
-    "FFMPEG_VERSION" = Get-FFmpegVersion
+    "FFMPEG_VERSION" = $latestFFmpegVersion
+    "FFMPEG_SOURCE_REF" = "n$latestFFmpegVersion"
     "RCLONE_VERSION" = Get-ReleaseTag -Repository "rclone/rclone"
     "IMAGEMAGICK_VERSION" = Get-ReleaseTag -Repository "ImageMagick/ImageMagick" -TrimV
 }


### PR DESCRIPTION
macOS already builds FFmpeg from source, but Linux and Windows jobs still pulled prebuilt binaries from `BtbN/FFmpeg-Builds`. This change aligns all platforms on source builds so the pipeline is consistent and easier to audit.

## What changed
- Added shared FFmpeg source wiring in workflow env: `FFMPEG_SOURCE_REF` plus Linux/Windows configure and make settings.
- Replaced download-based FFmpeg jobs with source builds for all four targets:
  - `ffmpeg-linux` (x64)
  - `ffmpeg-linux-arm64`
  - `ffmpeg-windows` (x64)
  - `ffmpeg-windows-arm64`
- Kept artifact names unchanged so existing release and Docker stages continue to consume the same filenames.
- Added post-build assertions for expected configure options and version output; Linux jobs also check for forbidden X11/xcb dynamic dependencies.
- Updated `scripts/Get-LatestImageMagickVersion.ps1` to resolve FFmpeg from official `FFmpeg/FFmpeg` tags and update both `FFMPEG_VERSION` and `FFMPEG_SOURCE_REF` together.

## Notes for reviewers
- Windows arm64 now builds on `windows-11-arm` using MSYS2 `CLANGARM64` packages.
- This intentionally removes FFmpeg version detection dependence on BtbN release asset naming.