### PR TITLE
Trim unused tools from release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,33 +16,16 @@ env:
   ZOPFLI_VERSION: "1.0.3" # https://github.com/google/zopfli/tags
   OXIPNG_VERSION: "10.1.1" # https://github.com/shssoichiro/oxipng/releases
   FFMPEG_VERSION: "8.1" # https://github.com/BtbN/FFmpeg-Builds/releases
-  FFMPEG_MACOS_SOURCE_REF: "n8.1" # https://github.com/FFmpeg/FFmpeg/tags (keep aligned with FFMPEG_VERSION)
-  AOM_VERSION: "3.13.1" # https://aomedia.googlesource.com/aom
-  OPUS_VERSION: "1.5.2" # https://opus-codec.org/downloads/
-  SVT_AV1_VERSION: "3.1.2" # https://gitlab.com/AOMediaCodec/SVT-AV1/-/tags
-  JXL_VERSION: "0.11.2" # https://github.com/libjxl/libjxl/releases
-  BROTLI_VERSION: "1.2.0" # https://github.com/google/brotli/releases
-  HWY_VERSION: "1.3.0" # https://github.com/google/highway/releases
-  # GPL profile. Nonfree options (for example libfdk-aac) are intentionally excluded.
-  FFMPEG_MACOS_CONFIGURE_FLAGS: >-
-    --arch=arm64 --target-os=darwin --disable-doc --disable-debug --enable-pthreads
-    --enable-runtime-cpudetect --enable-gpl --disable-nonfree --disable-shared --enable-static
-    --enable-audiotoolbox --enable-videotoolbox --enable-neon --disable-autodetect --pkg-config-flags=--static
-    --enable-libopus --enable-libaom --enable-libjxl --enable-libsvtav1
-    --disable-xlib --disable-libxcb --disable-libxcb-shm --disable-libxcb-xfixes --disable-libxcb-shape
-  FFMPEG_MACOS_MAKE_JOBS: "4"
-  RCLONE_VERSION: "v1.74.0" # https://github.com/rclone/rclone/releases
-  IMAGEMAGICK_VERSION: "7.1.2-21" # https://github.com/ImageMagick/ImageMagick/releases/latest
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
     needs: [
       versions_json,
-      zopflipng-linux,
-      zopflipng-linux-arm64,
-      zopflipng-windows,
-      zopflipng-osx-arm64,
+      zopfli-linux,
+      zopfli-linux-arm64,
+      zopfli-windows,
+      zopfli-osx-arm64,
       oxipng-linux,
       oxipng-linux-arm64,
       oxipng-windows,
@@ -51,17 +34,10 @@ jobs:
       ffmpeg-linux-arm64,
       ffmpeg-windows,
       ffmpeg-windows-arm64,
-      ffmpeg-osx-arm64,
-      ffmpeg-osx-arm64-avif-test,
       pngout-linux,
       pngout-linux-arm64,
       pngout-windows,
-      pngout-osx-arm64,
-      rclone-windows,
-      rclone-linux,
-      rclone-linux-arm64,
-      rclone-osx-arm64,
-      magick-windows
+      pngout-osx-arm64
     ]
     permissions:
       contents: write
@@ -96,8 +72,6 @@ jobs:
         $versions.Oxipng = "${{ env.OXIPNG_VERSION }}"
         $versions.FFmpeg = "${{ env.FFMPEG_VERSION }}"
         $versions.Pngout = "${{ env.PNGOUT_VERSION }}"
-        $versions.Rclone = "${{ env.RCLONE_VERSION }}"
-        $versions.ImageMagick = "${{ env.IMAGEMAGICK_VERSION }}"
         ConvertTo-Json $versions | Out-File versions.json
     - uses: actions/upload-artifact@v7
       with:
@@ -106,47 +80,41 @@ jobs:
         retention-days: 1
         path: 'versions.json'
 
-  zopflipng-linux:
+  zopfli-linux:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
       with:
         repository: google/zopfli
         ref: zopfli-${{ env.ZOPFLI_VERSION }}
-    - run: make zopfli && make zopflipng
+    - run: make zopfli
     - run: |
         mv zopfli zopfli-linux-x64
-        mv zopflipng zopflipng-linux-x64
     - uses: actions/upload-artifact@v7
       with:
-        name: binaries-zopflipng-linux
+        name: binaries-zopfli-linux
         if-no-files-found: error
         retention-days: 1
-        path: |
-          zopfli-linux-x64
-          zopflipng-linux-x64
+        path: zopfli-linux-x64
 
-  zopflipng-linux-arm64:
+  zopfli-linux-arm64:
     runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v6
       with:
         repository: google/zopfli
         ref: zopfli-${{ env.ZOPFLI_VERSION }}
-    - run: make zopfli && make zopflipng
+    - run: make zopfli
     - run: |
         mv zopfli zopfli-linux-arm64
-        mv zopflipng zopflipng-linux-arm64
     - uses: actions/upload-artifact@v7
       with:
-        name: binaries-zopflipng-linux-arm64
+        name: binaries-zopfli-linux-arm64
         if-no-files-found: error
         retention-days: 1
-        path: |
-          zopfli-linux-arm64
-          zopflipng-linux-arm64
+        path: zopfli-linux-arm64
 
-  zopflipng-windows:
+  zopfli-windows:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v6
@@ -166,44 +134,30 @@ jobs:
         Write-Host "Linking zopfli.exe"
         & link -nologo /LTCG /OUT:zopfli.exe *.obj user32.lib advapi32.lib kernel32.lib
 
-        Remove-Item zopfli_bin.obj
-        foreach($item in (Get-ChildItem src\zopflipng -Filter *.c* -Recurse)) {
-          Write-Host "Compiling $item"
-          & cl -nologo -O2 /GL /GS- /I$env:CRT_INC_PATH /I. -c /MD /DNDEBUG /EHsc "$item"
-        }
-
-        Write-Host "Linking zopflipng.exe"
-        & link -nologo /LTCG /OUT:zopflipng.exe *.obj user32.lib advapi32.lib kernel32.lib
         Move-Item zopfli.exe zopfli-win-x64.exe
-        Move-Item zopflipng.exe zopflipng-win-x64.exe
     - uses: actions/upload-artifact@v7
       with:
-        name: binaries-zopflipng-windows
+        name: binaries-zopfli-windows
         if-no-files-found: error
         retention-days: 1
-        path: |
-          zopfli-win-x64.exe
-          zopflipng-win-x64.exe
+        path: zopfli-win-x64.exe
 
-  zopflipng-osx-arm64:
+  zopfli-osx-arm64:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v6
       with:
         repository: google/zopfli
         ref: zopfli-${{ env.ZOPFLI_VERSION }}
-    - run: make zopfli && make zopflipng
+    - run: make zopfli
     - run: |
         Move-Item zopfli zopfli-osx-arm64
-        Move-Item zopflipng zopflipng-osx-arm64
     - uses: actions/upload-artifact@v7
       with:
-        name: binaries-zopflipng-osx-arm64
+        name: binaries-zopfli-osx-arm64
         if-no-files-found: error
         retention-days: 1
-        path: |
-          zopfli-osx-arm64
-          zopflipng-osx-arm64
+        path: zopfli-osx-arm64
 
   oxipng-windows:
     runs-on: ubuntu-latest
@@ -503,314 +457,16 @@ jobs:
            ffmpeg-linux-arm64
            ffprobe-linux-arm64
 
-  ffmpeg-osx-arm64:
-    runs-on: macos-latest
-    steps:
-    - run: |
-       brew install pkg-config cmake ninja nasm
-
-       $depsPrefix = Join-Path (Get-Location) "ffmpeg-deps"
-       New-Item -ItemType Directory -Path $depsPrefix -Force | Out-Null
-
-        function Invoke-StaticCMakeBuild([string]$sourcePath, [string]$buildPath, [string[]]$extraOptions) {
-         $cmakeConfigureArguments = @(
-           "-S", $sourcePath,
-           "-B", $buildPath,
-           "-G", "Ninja",
-           "-DCMAKE_BUILD_TYPE=Release",
-           "-DCMAKE_INSTALL_PREFIX=$depsPrefix",
-           "-DCMAKE_PREFIX_PATH=$depsPrefix",
-           "-DBUILD_SHARED_LIBS=OFF"
-         ) + $extraOptions
-
-         & cmake @cmakeConfigureArguments
-         if ($LASTEXITCODE -ne 0) {
-           throw "cmake configure failed for $sourcePath"
-         }
-
-         & cmake --build $buildPath --config Release --parallel ${{ env.FFMPEG_MACOS_MAKE_JOBS }}
-         if ($LASTEXITCODE -ne 0) {
-           throw "cmake build failed for $sourcePath"
-         }
-
-         & cmake --install $buildPath --config Release
-          if ($LASTEXITCODE -ne 0) {
-            throw "cmake install failed for $sourcePath"
-          }
-        }
-
-        function Invoke-DownloadWithRetry([string]$uri, [string]$archivePath, [string]$archiveType = "tar.gz") {
-          for ($attempt = 1; $attempt -le 5; $attempt++) {
-            try {
-              Invoke-WebRequest -Uri $uri -OutFile $archivePath -ErrorAction Stop
-            } catch {
-              if ($attempt -eq 5) {
-                throw
-              }
-              Start-Sleep -Seconds (2 * $attempt)
-              continue
-            }
-            if ($archiveType -eq "tar.gz") {
-              & tar -tzf $archivePath *> $null
-            } elseif ($archiveType -eq "zip") {
-              & unzip -tqq $archivePath *> $null
-            } else {
-              throw "Unsupported archive type: $archiveType"
-            }
-            if ($LASTEXITCODE -eq 0) {
-              return
-            }
-            if ($attempt -eq 5) {
-              throw "Failed to download a valid archive from $uri after $attempt attempts"
-            }
-            Remove-Item -LiteralPath $archivePath -Force -ErrorAction SilentlyContinue
-            Start-Sleep -Seconds (2 * $attempt)
-          }
-        }
-
-        Invoke-DownloadWithRetry -uri "https://github.com/google/brotli/archive/refs/tags/v${{ env.BROTLI_VERSION }}.tar.gz" -archivePath brotli.tar.gz
-        tar -xzf brotli.tar.gz
-        Invoke-StaticCMakeBuild -sourcePath "brotli-${{ env.BROTLI_VERSION }}" -buildPath "brotli-build" -extraOptions @(
-          "-DBROTLI_DISABLE_TESTS=ON"
-        )
-
-        Invoke-DownloadWithRetry -uri "https://github.com/google/highway/archive/refs/tags/${{ env.HWY_VERSION }}.tar.gz" -archivePath highway.tar.gz
-        tar -xzf highway.tar.gz
-        Invoke-StaticCMakeBuild -sourcePath "highway-${{ env.HWY_VERSION }}" -buildPath "highway-build" -extraOptions @(
-          "-DHWY_ENABLE_TESTS=OFF",
-          "-DHWY_ENABLE_EXAMPLES=OFF"
-        )
-
-        Invoke-DownloadWithRetry -uri "https://storage.googleapis.com/aom-releases/libaom-${{ env.AOM_VERSION }}.tar.gz" -archivePath libaom.tar.gz
-        tar -xzf libaom.tar.gz
-        Invoke-StaticCMakeBuild -sourcePath "libaom-${{ env.AOM_VERSION }}" -buildPath "libaom-build" -extraOptions @(
-          "-DENABLE_DOCS=OFF",
-          "-DENABLE_EXAMPLES=OFF",
-          "-DENABLE_TESTDATA=OFF",
-          "-DENABLE_TESTS=OFF",
-          "-DENABLE_TOOLS=OFF"
-        )
-
-        Invoke-DownloadWithRetry -uri "https://downloads.xiph.org/releases/opus/opus-${{ env.OPUS_VERSION }}.tar.gz" -archivePath opus.tar.gz
-        tar -xzf opus.tar.gz
-        Invoke-StaticCMakeBuild -sourcePath "opus-${{ env.OPUS_VERSION }}" -buildPath "opus-build" -extraOptions @(
-          "-DOPUS_BUILD_PROGRAMS=OFF",
-          "-DOPUS_BUILD_TESTING=OFF",
-          "-DOPUS_BUILD_SHARED_LIBRARY=OFF",
-          "-DOPUS_BUILD_STATIC_LIBRARY=ON"
-        )
-
-        Invoke-DownloadWithRetry -uri "https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v${{ env.SVT_AV1_VERSION }}/SVT-AV1-v${{ env.SVT_AV1_VERSION }}.tar.gz" -archivePath svt-av1.tar.gz
-        tar -xzf svt-av1.tar.gz
-        Invoke-StaticCMakeBuild -sourcePath "SVT-AV1-v${{ env.SVT_AV1_VERSION }}" -buildPath "svt-av1-build" -extraOptions @(
-          "-DBUILD_APPS=OFF",
-          "-DBUILD_DEC=OFF",
-          "-DBUILD_TESTING=OFF",
-          "-DSVT_AV1_LTO=OFF"
-        )
-
-        Invoke-DownloadWithRetry -uri "https://github.com/libjxl/libjxl/archive/refs/tags/v${{ env.JXL_VERSION }}.tar.gz" -archivePath libjxl.tar.gz
-        $libjxlSourceDirectory = "libjxl-${{ env.JXL_VERSION }}"
-        for ($attempt = 1; $attempt -le 5; $attempt++) {
-          Remove-Item -LiteralPath $libjxlSourceDirectory -Recurse -Force -ErrorAction SilentlyContinue
-          tar -xzf libjxl.tar.gz
-          Push-Location $libjxlSourceDirectory
-          & bash "./deps.sh"
-          $depsExitCode = $LASTEXITCODE
-          Pop-Location
-          if ($depsExitCode -eq 0) {
-            break
-          }
-          if ($attempt -eq 5) {
-            throw "Failed to fetch libjxl build dependencies"
-          }
-          Start-Sleep -Seconds (2 * $attempt)
-        }
-         Invoke-StaticCMakeBuild -sourcePath $libjxlSourceDirectory -buildPath "libjxl-build" -extraOptions @(
-           "-DBUILD_TESTING=OFF",
-           "-DJPEGXL_ENABLE_TESTS=OFF",
-           "-DJPEGXL_ENABLE_TOOLS=OFF",
-          "-DJPEGXL_ENABLE_EXAMPLES=OFF",
-          "-DJPEGXL_ENABLE_DOXYGEN=OFF",
-          "-DJPEGXL_ENABLE_MANPAGES=OFF",
-          "-DJPEGXL_ENABLE_JPEGLI=OFF",
-          "-DJPEGXL_ENABLE_BENCHMARK=OFF",
-          "-DJPEGXL_ENABLE_SJPEG=OFF",
-          "-DJPEGXL_VERSION=${{ env.JXL_VERSION }}",
-          "-DJPEGXL_FORCE_SYSTEM_BROTLI=ON",
-          "-DJPEGXL_FORCE_SYSTEM_HWY=ON"
-        )
-
-       $pkgConfigPaths = @(
-         (Join-Path $depsPrefix "lib/pkgconfig"),
-         (Join-Path $depsPrefix "lib64/pkgconfig")
-       ) | Where-Object { Test-Path -LiteralPath $_ -PathType Container }
-       if (-not $pkgConfigPaths) {
-         throw "pkg-config directories were not generated in $depsPrefix"
-       }
-
-        $pkgConfigPathValue = [string]::Join([IO.Path]::PathSeparator, $pkgConfigPaths)
-        $env:PKG_CONFIG_PATH = $pkgConfigPathValue
-        $env:PKG_CONFIG_LIBDIR = $pkgConfigPathValue
-        $env:CFLAGS = "-I$(Join-Path $depsPrefix 'include')"
-        $env:CXXFLAGS = "-I$(Join-Path $depsPrefix 'include')"
-
-        foreach ($pkgConfigDirectory in $pkgConfigPaths) {
-          foreach ($pkgConfigFile in @("libjxl.pc", "libjxl_threads.pc")) {
-            $pkgConfigFilePath = Join-Path $pkgConfigDirectory $pkgConfigFile
-            if (Test-Path -LiteralPath $pkgConfigFilePath -PathType Leaf) {
-              $pkgConfigContent = Get-Content -Raw -LiteralPath $pkgConfigFilePath
-              $pkgConfigContent = $pkgConfigContent -replace '(?m)^Version:.*$', "Version: ${{ env.JXL_VERSION }}"
-              Set-Content -LiteralPath $pkgConfigFilePath -Value $pkgConfigContent
-            }
-          }
-        }
-
-       $linkerSearchPaths = @(
-         (Join-Path $depsPrefix "lib"),
-         (Join-Path $depsPrefix "lib64")
-       ) | Where-Object { Test-Path -LiteralPath $_ -PathType Container }
-        if (-not $linkerSearchPaths) {
-          throw "linker search paths were not generated in $depsPrefix"
-        }
-        $env:LDFLAGS = (($linkerSearchPaths | ForEach-Object { "-L$_" }) -join ' ') + " -lc++"
-
-        $requiredPkgConfigPackages = @(
-          "aom",
-          "opus",
-          "SvtAv1Enc",
-          "libjxl >= 0.7.0",
-          "libjxl_threads >= 0.7.0"
-         )
-         foreach ($pkgName in $requiredPkgConfigPackages) {
-           & pkg-config --exists --print-errors --static $pkgName
-           if ($LASTEXITCODE -ne 0) {
-             throw "pkg-config package '$pkgName' was not found in static dependency prefix"
-           }
-         }
-
-        Invoke-DownloadWithRetry -uri "https://github.com/FFmpeg/FFmpeg/archive/refs/tags/${{ env.FFMPEG_MACOS_SOURCE_REF }}.tar.gz" -archivePath ffmpeg.tar.gz
-        tar -xzf ffmpeg.tar.gz
-
-       $sourceDirectory = "FFmpeg-${{ env.FFMPEG_MACOS_SOURCE_REF }}"
-       if (-not (Test-Path -LiteralPath $sourceDirectory -PathType Container)) {
-         throw "ffmpeg source directory not found: $sourceDirectory"
-       }
-
-       $configureFlags = "${{ env.FFMPEG_MACOS_CONFIGURE_FLAGS }}" -split '\s+' | Where-Object { $_ }
-       Push-Location $sourceDirectory
-       & ./configure @configureFlags
-       & make -j${{ env.FFMPEG_MACOS_MAKE_JOBS }}
-
-       Move-Item -LiteralPath ./ffmpeg -Destination ../ffmpeg-osx-arm64
-       Move-Item -LiteralPath ./ffprobe -Destination ../ffprobe-osx-arm64
-       Pop-Location
-
-       chmod +x ffmpeg-osx-arm64
-       chmod +x ffprobe-osx-arm64
-
-       function Get-ExternalDependencies([string]$path) {
-         return (& otool -L $path | Select-Object -Skip 1 | ForEach-Object {
-           ($_ -replace '^\s+', '') -replace '\s+\(.*$',''
-         } | Where-Object { $_ -and $_ -notmatch '^/usr/lib/' -and $_ -notmatch '^/System/Library/' })
-       }
-
-       function Assert-NoExternalDependencies([string]$binaryName, [string[]]$dependencies) {
-         if ($dependencies) {
-           throw "$binaryName has non-system dynamic dependencies: $($dependencies -join ', ')"
-         }
-       }
-
-       $ffmpegExternalDependencies = Get-ExternalDependencies "./ffmpeg-osx-arm64"
-       Assert-NoExternalDependencies "ffmpeg-osx-arm64" $ffmpegExternalDependencies
-       if ($ffmpegExternalDependencies) {
-         Write-Host "ffmpeg-osx-arm64 external dependencies: $($ffmpegExternalDependencies -join ', ')"
-       }
-
-       $ffprobeExternalDependencies = Get-ExternalDependencies "./ffprobe-osx-arm64"
-       Assert-NoExternalDependencies "ffprobe-osx-arm64" $ffprobeExternalDependencies
-       if ($ffprobeExternalDependencies) {
-         Write-Host "ffprobe-osx-arm64 external dependencies: $($ffprobeExternalDependencies -join ', ')"
-       }
-
-       function Assert-ConfigureOptionEnabled([string]$option) {
-         $buildConfig = & ./ffmpeg-osx-arm64 -buildconf | Out-String
-         if ($buildConfig -notmatch [Regex]::Escape($option)) {
-           throw "Missing expected FFmpeg configure option: $option"
-         }
-       }
-
-       Assert-ConfigureOptionEnabled "--enable-gpl"
-       Assert-ConfigureOptionEnabled "--enable-libopus"
-       Assert-ConfigureOptionEnabled "--enable-libaom"
-       Assert-ConfigureOptionEnabled "--enable-libjxl"
-       Assert-ConfigureOptionEnabled "--enable-libsvtav1"
-
-       $ffmpegVersion = & ./ffmpeg-osx-arm64 -version | Select-Object -First 1
-       $ffprobeVersion = & ./ffprobe-osx-arm64 -version | Select-Object -First 1
-       Write-Host "Built $ffmpegVersion"
-       Write-Host "Built $ffprobeVersion"
-    - uses: actions/upload-artifact@v7
-      with:
-        name: binaries-ffmpeg-osx-arm64
-        if-no-files-found: error
-        retention-days: 1
-        path: |
-           ffmpeg-osx-arm64
-           ffprobe-osx-arm64
-
-  ffmpeg-osx-arm64-avif-test:
-    runs-on: macos-latest
-    needs: [ffmpeg-osx-arm64]
-    steps:
-    - uses: actions/download-artifact@v8
-      with:
-        name: binaries-ffmpeg-osx-arm64
-        path: .
-    - run: |
-       chmod +x ffmpeg-osx-arm64
-       chmod +x ffprobe-osx-arm64
-
-       @"
-       P3
-       2 2
-       255
-       255 0 0   0 255 0
-       0 0 255   255 255 255
-       "@ | Set-Content -LiteralPath input.ppm
-
-       & ./ffmpeg-osx-arm64 -y -v error -i ./input.ppm -frames:v 1 -c:v libaom-av1 -still-picture 1 -cpu-used 8 -row-mt 1 -vf "scale=4:4,format=yuv420p" ./output.avif
-       if ($LASTEXITCODE -ne 0) {
-         throw "ffmpeg failed to encode input.ppm to AVIF"
-       }
-
-       if (-not (Test-Path -LiteralPath ./output.avif -PathType Leaf)) {
-         throw "output.avif was not created"
-       }
-
-       $outputSize = (Get-Item -LiteralPath ./output.avif).Length
-       if ($outputSize -le 0) {
-         throw "output.avif is empty"
-       }
-
-       $codecName = (& ./ffprobe-osx-arm64 -v error -select_streams v:0 -show_entries stream=codec_name -of default=nokey=1:noprint_wrappers=1 ./output.avif | Out-String).Trim()
-       if ($LASTEXITCODE -ne 0) {
-         throw "ffprobe failed to inspect output.avif"
-       }
-       if ($codecName -ne "av1") {
-         throw "Unexpected codec for output.avif: '$codecName'"
-       }
-
   prebuilt-docker-linux-x64:
     runs-on: ubuntu-latest
-    needs: [zopflipng-linux, oxipng-linux, pngout-linux, ffmpeg-linux, rclone-linux]
+    needs: [zopfli-linux, oxipng-linux, pngout-linux, ffmpeg-linux]
     permissions:
       contents: read
       packages: write
     steps:
     - uses: actions/download-artifact@v8
       with:
-        name: binaries-zopflipng-linux
+        name: binaries-zopfli-linux
         path: .
     - uses: actions/download-artifact@v8
       with:
@@ -824,20 +480,14 @@ jobs:
       with:
         name: binaries-ffmpeg-linux
         path: .
-    - uses: actions/download-artifact@v8
-      with:
-        name: binaries-rclone-linux
-        path: .
     - run: |
        @"
        FROM ubuntu:24.04
        COPY --chmod=0755 zopfli-linux-x64 /usr/local/bin/zopfli
-       COPY --chmod=0755 zopflipng-linux-x64 /usr/local/bin/zopflipng
        COPY --chmod=0755 oxipng-linux-x64 /usr/local/bin/oxipng
        COPY --chmod=0755 pngout-linux-x64 /usr/local/bin/pngout
        COPY --chmod=0755 ffmpeg-linux-x64 /usr/local/bin/ffmpeg
        COPY --chmod=0755 ffprobe-linux-x64 /usr/local/bin/ffprobe
-       COPY --chmod=0755 rclone-linux-x64 /usr/local/bin/rclone
        "@ | Set-Content -LiteralPath Dockerfile -NoNewline
     - uses: docker/setup-buildx-action@v4
     - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -856,14 +506,14 @@ jobs:
 
   prebuilt-docker-linux-arm64:
     runs-on: ubuntu-latest
-    needs: [zopflipng-linux-arm64, oxipng-linux-arm64, pngout-linux-arm64, ffmpeg-linux-arm64, rclone-linux-arm64]
+    needs: [zopfli-linux-arm64, oxipng-linux-arm64, pngout-linux-arm64, ffmpeg-linux-arm64]
     permissions:
       contents: read
       packages: write
     steps:
     - uses: actions/download-artifact@v8
       with:
-        name: binaries-zopflipng-linux-arm64
+        name: binaries-zopfli-linux-arm64
         path: .
     - uses: actions/download-artifact@v8
       with:
@@ -877,20 +527,14 @@ jobs:
       with:
         name: binaries-ffmpeg-linux-arm64
         path: .
-    - uses: actions/download-artifact@v8
-      with:
-        name: binaries-rclone-linux-arm64
-        path: .
     - run: |
        @"
        FROM ubuntu:24.04
        COPY --chmod=0755 zopfli-linux-arm64 /usr/local/bin/zopfli
-       COPY --chmod=0755 zopflipng-linux-arm64 /usr/local/bin/zopflipng
        COPY --chmod=0755 oxipng-linux-arm64 /usr/local/bin/oxipng
        COPY --chmod=0755 pngout-linux-arm64 /usr/local/bin/pngout
        COPY --chmod=0755 ffmpeg-linux-arm64 /usr/local/bin/ffmpeg
        COPY --chmod=0755 ffprobe-linux-arm64 /usr/local/bin/ffprobe
-       COPY --chmod=0755 rclone-linux-arm64 /usr/local/bin/rclone
        "@ | Set-Content -LiteralPath Dockerfile -NoNewline
     - uses: docker/setup-buildx-action@v4
     - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -929,103 +573,3 @@ jobs:
          "${registry}:${{ env.VERSION }}-linux-x64" `
          "${registry}:${{ env.VERSION }}-linux-arm64"
        docker buildx imagetools inspect "${registry}:${{ env.VERSION }}"
-
-  rclone-windows:
-    runs-on: ubuntu-latest
-    steps:
-    - run: |
-       $headers = @{
-         "User-Agent" = "GitHub Actions"
-         "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
-       }
-
-        $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/rclone/rclone/releases/tags/${{ env.RCLONE_VERSION }} -Headers $headers
-        $WindowsAsset = $release.assets | Where-Object { $_.name -cmatch '^rclone-.*-windows-amd64.zip$' }
-        Invoke-WebRequest -Uri $WindowsAsset.browser_download_url -OutFile rclone.zip
-        Expand-Archive rclone.zip -DestinationPath . -Verbose
-        Get-ChildItem -Recurse -Include rclone.exe | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
-        Move-Item rclone.exe rclone-win-x64.exe
-    - uses: actions/upload-artifact@v7
-      with:
-        name: binaries-rclone-windows
-        if-no-files-found: error
-        retention-days: 1
-        path: rclone-win-x64.exe
-
-  rclone-linux:
-    runs-on: ubuntu-latest
-    steps:
-    - run: |
-       $headers = @{
-         "User-Agent" = "GitHub Actions"
-         "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
-       }
-
-        $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/rclone/rclone/releases/tags/${{ env.RCLONE_VERSION }} -Headers $headers
-        $LinuxAsset = $release.assets | Where-Object { $_.name -cmatch '^rclone-.*-linux-amd64.zip$' }
-        Invoke-WebRequest -Uri $LinuxAsset.browser_download_url -OutFile rclone.zip
-        Expand-Archive rclone.zip -DestinationPath . -Verbose
-        Get-ChildItem -Recurse -Include rclone | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
-        Move-Item rclone rclone-linux-x64
-    - uses: actions/upload-artifact@v7
-      with:
-        name: binaries-rclone-linux
-        if-no-files-found: error
-        retention-days: 1
-        path: rclone-linux-x64
-
-  rclone-linux-arm64:
-    runs-on: ubuntu-latest
-    steps:
-    - run: |
-       $headers = @{
-         "User-Agent" = "GitHub Actions"
-         "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
-       }
-
-        $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/rclone/rclone/releases/tags/${{ env.RCLONE_VERSION }} -Headers $headers
-        $LinuxAsset = $release.assets | Where-Object { $_.name -cmatch '^rclone-.*-linux-arm64.zip$' }
-        Invoke-WebRequest -Uri $LinuxAsset.browser_download_url -OutFile rclone.zip
-        Expand-Archive rclone.zip -DestinationPath . -Verbose
-        Get-ChildItem -Recurse -Include rclone | Foreach-Object { Move-Item -LiteralPath $_ -Destination . }
-        Move-Item rclone rclone-linux-arm64
-    - uses: actions/upload-artifact@v7
-      with:
-        name: binaries-rclone-linux-arm64
-        if-no-files-found: error
-        retention-days: 1
-        path: rclone-linux-arm64
-
-  rclone-osx-arm64:
-    runs-on: ubuntu-latest
-    steps:
-    - run: |
-       $headers = @{
-         "User-Agent" = "GitHub Actions"
-         "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
-       }
-
-       $release = Invoke-RestMethod -Method Get -Uri https://api.github.com/repos/rclone/rclone/releases/tags/${{ env.RCLONE_VERSION }} -Headers $headers
-       $MacAsset = $release.assets | Where-Object { $_.name -cmatch '^rclone-.*-osx-arm64.zip$' }
-       Invoke-WebRequest -Uri $MacAsset.browser_download_url -OutFile rclone.zip
-       Expand-Archive rclone.zip -DestinationPath . -Verbose
-       Get-ChildItem -Recurse -Include rclone | Foreach-Object { Move-Item -LiteralPath $_ -Destination rclone-osx-arm64 }
-    - uses: actions/upload-artifact@v7
-      with:
-        name: binaries-rclone-osx-arm64
-        if-no-files-found: error
-        retention-days: 1
-        path: rclone-osx-arm64
-
-  magick-windows:
-    runs-on: ubuntu-latest
-    steps:
-    - run: Invoke-WebRequest -Uri 'https://imagemagick.org/archive/binaries/ImageMagick-${{ env.IMAGEMAGICK_VERSION }}-portable-Q16-HDRI-x64.7z' -OutFile ImageMagick.7z
-    - run: 7z x ImageMagick.7z
-    - run: Move-Item magick.exe magick-win-x64.exe
-    - uses: actions/upload-artifact@v7
-      with:
-        name: binaries-imagemagick-windows
-        if-no-files-found: error
-        retention-days: 1
-        path: magick-win-x64.exe

--- a/scripts/Get-LatestVersions.ps1
+++ b/scripts/Get-LatestVersions.ps1
@@ -153,8 +153,6 @@ $availableLatestVersions = [ordered]@{
     "ZOPFLI_VERSION" = Get-ZopfliVersion
     "OXIPNG_VERSION" = Get-ReleaseTag -Repository "shssoichiro/oxipng" -TrimV
     "FFMPEG_VERSION" = Get-FFmpegVersion
-    "RCLONE_VERSION" = Get-ReleaseTag -Repository "rclone/rclone"
-    "IMAGEMAGICK_VERSION" = Get-ReleaseTag -Repository "ImageMagick/ImageMagick" -TrimV
 }
 
 $selectedVariableNames =


### PR DESCRIPTION
This updates the release pipeline to only build and publish the toolset we still need, reducing CI surface area and keeping the workflow aligned with current release contents.

### What changed
- Removed rclone and ImageMagick from `create-release`, `versions_json`, and their dedicated build jobs.
- Removed `zopflipng` from release artifacts while keeping `zopfli`; renamed the related jobs/artifacts from `zopflipng-*` to `zopfli-*`.
- Removed macOS FFmpeg build and AVIF validation jobs (`ffmpeg-osx-arm64` and `ffmpeg-osx-arm64-avif-test`).
- Updated Docker image assembly jobs to consume `zopfli` artifacts and stop copying `zopflipng` and `rclone` binaries.
- Renamed `scripts/Get-LatestImageMagickVersion.ps1` to `scripts/Get-LatestVersions.ps1` and removed no-longer-used `RCLONE_VERSION` and `IMAGEMAGICK_VERSION` update entries.

### Notes
- Linux and Windows FFmpeg builds remain in place.
- No PR template is present in this repository, so this description is provided in freeform.