### PR TITLE
Add pngquant binaries to CI releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,11 @@ defaults:
     shell: pwsh
 
 env:
-  VERSION: 2.0.8
+  VERSION: 2.0.9
   PNGOUT_VERSION: 1.0.0 # http://advsys.net/ken/utils.htm#pngout - manual version
   ZOPFLI_VERSION: "1.0.3" # https://github.com/google/zopfli/tags
   OXIPNG_VERSION: "10.1.1" # https://github.com/shssoichiro/oxipng/releases
+  PNGQUANT_VERSION: "3.0.3" # https://github.com/kornelski/pngquant/tags
   FFMPEG_VERSION: "8.1" # https://github.com/BtbN/FFmpeg-Builds/releases
 
 jobs:
@@ -30,6 +31,10 @@ jobs:
       oxipng-linux-arm64,
       oxipng-windows,
       oxipng-osx-arm64,
+      pngquant-linux,
+      pngquant-linux-arm64,
+      pngquant-windows,
+      pngquant-osx-arm64,
       ffmpeg-linux,
       ffmpeg-linux-arm64,
       ffmpeg-windows,
@@ -70,6 +75,7 @@ jobs:
         $versions = @{}
         $versions.Zopfli = "${{ env.ZOPFLI_VERSION }}"
         $versions.Oxipng = "${{ env.OXIPNG_VERSION }}"
+        $versions.Pngquant = "${{ env.PNGQUANT_VERSION }}"
         $versions.FFmpeg = "${{ env.FFMPEG_VERSION }}"
         $versions.Pngout = "${{ env.PNGOUT_VERSION }}"
         ConvertTo-Json $versions | Out-File versions.json
@@ -301,6 +307,78 @@ jobs:
         retention-days: 1
         path: 'oxipng-osx-arm64'
 
+  pngquant-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        repository: kornelski/pngquant
+        ref: ${{ env.PNGQUANT_VERSION }}
+        submodules: recursive
+    - uses: dtolnay/rust-toolchain@stable
+    - run: cargo build --release --locked
+    - run: Move-Item target/release/pngquant.exe pngquant-win-x64.exe
+    - uses: actions/upload-artifact@v7
+      with:
+        name: binaries-pngquant-windows
+        if-no-files-found: error
+        retention-days: 1
+        path: pngquant-win-x64.exe
+
+  pngquant-linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        repository: kornelski/pngquant
+        ref: ${{ env.PNGQUANT_VERSION }}
+        submodules: recursive
+    - uses: dtolnay/rust-toolchain@stable
+    - run: cargo build --release --locked
+    - run: mv target/release/pngquant pngquant-linux-x64
+    - uses: actions/upload-artifact@v7
+      with:
+        name: binaries-pngquant-linux
+        if-no-files-found: error
+        retention-days: 1
+        path: pngquant-linux-x64
+
+  pngquant-linux-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        repository: kornelski/pngquant
+        ref: ${{ env.PNGQUANT_VERSION }}
+        submodules: recursive
+    - uses: dtolnay/rust-toolchain@stable
+    - run: cargo build --release --locked
+    - run: mv target/release/pngquant pngquant-linux-arm64
+    - uses: actions/upload-artifact@v7
+      with:
+        name: binaries-pngquant-linux-arm64
+        if-no-files-found: error
+        retention-days: 1
+        path: pngquant-linux-arm64
+
+  pngquant-osx-arm64:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        repository: kornelski/pngquant
+        ref: ${{ env.PNGQUANT_VERSION }}
+        submodules: recursive
+    - uses: dtolnay/rust-toolchain@stable
+    - run: cargo build --release --locked
+    - run: Move-Item target/release/pngquant pngquant-osx-arm64
+    - uses: actions/upload-artifact@v7
+      with:
+        name: binaries-pngquant-osx-arm64
+        if-no-files-found: error
+        retention-days: 1
+        path: pngquant-osx-arm64
+
   pngout-windows:
     runs-on: ubuntu-latest
     steps:
@@ -459,7 +537,7 @@ jobs:
 
   prebuilt-docker-linux-x64:
     runs-on: ubuntu-latest
-    needs: [zopfli-linux, oxipng-linux, pngout-linux, ffmpeg-linux]
+    needs: [zopfli-linux, oxipng-linux, pngquant-linux, pngout-linux, ffmpeg-linux]
     permissions:
       contents: read
       packages: write
@@ -478,15 +556,20 @@ jobs:
         path: .
     - uses: actions/download-artifact@v8
       with:
+        name: binaries-pngquant-linux
+        path: .
+    - uses: actions/download-artifact@v8
+      with:
         name: binaries-ffmpeg-linux
         path: .
     - run: |
        @"
        FROM ubuntu:24.04
-       COPY --chmod=0755 zopfli-linux-x64 /usr/local/bin/zopfli
-       COPY --chmod=0755 oxipng-linux-x64 /usr/local/bin/oxipng
-       COPY --chmod=0755 pngout-linux-x64 /usr/local/bin/pngout
-       COPY --chmod=0755 ffmpeg-linux-x64 /usr/local/bin/ffmpeg
+        COPY --chmod=0755 zopfli-linux-x64 /usr/local/bin/zopfli
+        COPY --chmod=0755 oxipng-linux-x64 /usr/local/bin/oxipng
+        COPY --chmod=0755 pngquant-linux-x64 /usr/local/bin/pngquant
+        COPY --chmod=0755 pngout-linux-x64 /usr/local/bin/pngout
+        COPY --chmod=0755 ffmpeg-linux-x64 /usr/local/bin/ffmpeg
        COPY --chmod=0755 ffprobe-linux-x64 /usr/local/bin/ffprobe
        "@ | Set-Content -LiteralPath Dockerfile -NoNewline
     - uses: docker/setup-buildx-action@v4
@@ -506,7 +589,7 @@ jobs:
 
   prebuilt-docker-linux-arm64:
     runs-on: ubuntu-latest
-    needs: [zopfli-linux-arm64, oxipng-linux-arm64, pngout-linux-arm64, ffmpeg-linux-arm64]
+    needs: [zopfli-linux-arm64, oxipng-linux-arm64, pngquant-linux-arm64, pngout-linux-arm64, ffmpeg-linux-arm64]
     permissions:
       contents: read
       packages: write
@@ -525,15 +608,20 @@ jobs:
         path: .
     - uses: actions/download-artifact@v8
       with:
+        name: binaries-pngquant-linux-arm64
+        path: .
+    - uses: actions/download-artifact@v8
+      with:
         name: binaries-ffmpeg-linux-arm64
         path: .
     - run: |
        @"
        FROM ubuntu:24.04
-       COPY --chmod=0755 zopfli-linux-arm64 /usr/local/bin/zopfli
-       COPY --chmod=0755 oxipng-linux-arm64 /usr/local/bin/oxipng
-       COPY --chmod=0755 pngout-linux-arm64 /usr/local/bin/pngout
-       COPY --chmod=0755 ffmpeg-linux-arm64 /usr/local/bin/ffmpeg
+        COPY --chmod=0755 zopfli-linux-arm64 /usr/local/bin/zopfli
+        COPY --chmod=0755 oxipng-linux-arm64 /usr/local/bin/oxipng
+        COPY --chmod=0755 pngquant-linux-arm64 /usr/local/bin/pngquant
+        COPY --chmod=0755 pngout-linux-arm64 /usr/local/bin/pngout
+        COPY --chmod=0755 ffmpeg-linux-arm64 /usr/local/bin/ffmpeg
        COPY --chmod=0755 ffprobe-linux-arm64 /usr/local/bin/ffprobe
        "@ | Set-Content -LiteralPath Dockerfile -NoNewline
     - uses: docker/setup-buildx-action@v4

--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,17 @@
         "/^\\.github/workflows/ci\\.yml$/"
       ],
       "matchStrings": [
+        "PNGQUANT_VERSION: \"(?<currentValue>.*?)\""
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "kornelski/pngquant"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/ci\\.yml$/"
+      ],
+      "matchStrings": [
         "FFMPEG_VERSION: \"(?<currentValue>.*?)\""
       ],
       "datasourceTemplate": "github-releases",

--- a/scripts/Get-LatestVersions.ps1
+++ b/scripts/Get-LatestVersions.ps1
@@ -61,6 +61,25 @@ function Get-ZopfliVersion {
     return ($versions | Sort-Object Version -Descending | Select-Object -First 1).Text
 }
 
+function Get-PngquantVersion {
+    $tags = Invoke-GitHubApi -Uri "https://api.github.com/repos/kornelski/pngquant/tags?per_page=100"
+    $versions =
+        foreach ($tag in $tags) {
+            if ($tag.name -match "^[vV]?(?<version>\d+\.\d+\.\d+)$") {
+                [PSCustomObject]@{
+                    Version = [version]$Matches["version"]
+                    Text = $Matches["version"]
+                }
+            }
+        }
+
+    if (-not $versions) {
+        throw "Unable to determine latest pngquant version."
+    }
+
+    return ($versions | Sort-Object Version -Descending | Select-Object -First 1).Text
+}
+
 function Get-FFmpegVersion {
     $release = Invoke-GitHubApi -Uri "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest"
     $assets = @($release.assets)
@@ -152,6 +171,7 @@ if ([string]::IsNullOrEmpty($workflowContent)) {
 $availableLatestVersions = [ordered]@{
     "ZOPFLI_VERSION" = Get-ZopfliVersion
     "OXIPNG_VERSION" = Get-ReleaseTag -Repository "shssoichiro/oxipng" -TrimV
+    "PNGQUANT_VERSION" = Get-PngquantVersion
     "FFMPEG_VERSION" = Get-FFmpegVersion
 }
 


### PR DESCRIPTION
This adds pngquant to the released toolchain so prebuilt publishes a complete PNG optimization set alongside zopfli, oxipng, and pngout.

## What changed
- bumped workflow `VERSION` to `2.0.9` and added `PNGQUANT_VERSION` (`3.0.3`)
- added pngquant build jobs for Linux x64, Linux arm64, Windows x64, and macOS arm64
- added pngquant artifacts to `create-release` and to `versions.json`
- included pngquant in both Docker image builds (`linux-x64` and `linux-arm64`)
- extended `scripts/Get-LatestVersions.ps1` with `Get-PngquantVersion` and `PNGQUANT_VERSION` update support
- added Renovate tracking for `PNGQUANT_VERSION` from `kornelski/pngquant` tags

## Notes
- pngquant is built from source from the upstream `kornelski/pngquant` tag, matching the existing CI packaging model for cross-platform binaries.